### PR TITLE
Add _modify accessors to passthrough/wrapper computed properties

### DIFF
--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x2.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x2.swift
@@ -51,6 +51,9 @@ public struct Matrix2x2<Scalar:ExtendedSIMDScalar> :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x3.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x3.swift
@@ -54,6 +54,9 @@ public struct Matrix2x3<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x4.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix2x4.swift
@@ -54,6 +54,9 @@ public struct Matrix2x4<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x2.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x2.swift
@@ -55,6 +55,9 @@ public struct Matrix3x2<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x3.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x3.swift
@@ -53,6 +53,9 @@ public struct Matrix3x3<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x4.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix3x4.swift
@@ -55,6 +55,9 @@ public struct Matrix3x4<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x2.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x2.swift
@@ -55,6 +55,9 @@ public struct Matrix4x2<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x3.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x3.swift
@@ -55,6 +55,9 @@ public struct Matrix4x3<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x4.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Matrices/Matrix4x4.swift
@@ -53,6 +53,9 @@ public struct Matrix4x4<Scalar:ExtendedSIMDScalar>  :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/Passthrough/Passthrough+MatrixProtocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Passthrough/Passthrough+MatrixProtocol.swift
@@ -182,6 +182,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     set {
       passthroughValue[columnIndex: columnIndex] = newValue
     }
+    _modify {
+      yield &passthroughValue[columnIndex: columnIndex]
+    }
   }
   
   // ------------------------------------------------------------------------ //
@@ -197,6 +200,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     set {
       passthroughValue[rowIndex: rowIndex] = newValue
     }
+    _modify {
+      yield &passthroughValue[rowIndex: rowIndex]
+    }
   }
   
   // ------------------------------------------------------------------------ //
@@ -211,6 +217,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     set {
       passthroughValue[linearizedScalarIndex: linearizedScalarIndex] = newValue
     }
+    _modify {
+      yield &passthroughValue[linearizedScalarIndex: linearizedScalarIndex]
+    }
   }
   
   @inlinable
@@ -224,7 +233,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     set {
       passthroughValue[columnIndex: columnIndex, rowIndex: rowIndex] = newValue
     }
-    
+    _modify {
+      yield &passthroughValue[columnIndex: columnIndex, rowIndex: rowIndex]
+    }
   }
   
   @inlinable
@@ -234,6 +245,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     }
     set {
       passthroughValue[position: position] = newValue
+    }
+    _modify {
+      yield &passthroughValue[position: position]
     }
   }
   
@@ -313,6 +327,9 @@ public extension Passthrough where PassthroughValue: MatrixProtocol {
     }
     set {
       passthroughValue.columns = newValue
+    }
+    _modify {
+      yield &passthroughValue.columns
     }
   }
 

--- a/Sources/HDXLSIMDSupport/Matrices/Protocols/DefaultSupport/MatrixDefaultSupportProtocol+ScalarSubscriptingDefaults.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Protocols/DefaultSupport/MatrixDefaultSupportProtocol+ScalarSubscriptingDefaults.swift
@@ -27,6 +27,12 @@ public extension MatrixDefaultSupportProtocol {
         )
       ] = newValue
     }
+    _modify {
+      let position = Self.matrixPosition(
+        forLinearizedScalarIndex: linearizedScalarIndex
+      )
+      yield &self[position: position]
+    }
   }
 
   @inlinable
@@ -51,8 +57,18 @@ public extension MatrixDefaultSupportProtocol {
         rowIndex: position.rowIndex
       ] = newValue
     }
+    _modify {
+      // ///////////////////////////////////////////////////////////////////////
+      pedantic_assert(position.isValid)
+      pedantic_assert(Self.contains(position: position))
+      // ///////////////////////////////////////////////////////////////////////
+      yield &self[
+        columnIndex: position.columnIndex,
+        rowIndex: position.rowIndex
+      ]
+    }
   }
-  
+
   @inlinable
   subscript(columnIndex columnIndex: Int, rowIndex rowIndex: Int) -> Scalar {
     get {
@@ -64,6 +80,11 @@ public extension MatrixDefaultSupportProtocol {
       precondition(Self.columnIndexRange.contains(columnIndex))
       precondition(Self.rowIndexRange.contains(rowIndex))
       self[columnIndex: columnIndex][rowIndex] = newValue
+    }
+    _modify {
+      precondition(Self.columnIndexRange.contains(columnIndex))
+      precondition(Self.rowIndexRange.contains(rowIndex))
+      yield &self[columnIndex: columnIndex][rowIndex]
     }
   }
 

--- a/Sources/HDXLSIMDSupport/Matrices/Protocols/DefaultSupport/MatrixDefaultSupportProtocol+ShapeDefaults.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Protocols/DefaultSupport/MatrixDefaultSupportProtocol+ShapeDefaults.swift
@@ -258,6 +258,17 @@ public extension MatrixDefaultSupportProtocol
         fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
       }
     }
+    _modify {
+      precondition(Self.columnIndexRange.contains(columnIndex))
+      switch columnIndex {
+      case 0:
+        yield &columns.0
+      case 1:
+        yield &columns.1
+      default:
+        fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
+      }
+    }
   }
 
   @inlinable
@@ -350,6 +361,19 @@ public extension MatrixDefaultSupportProtocol
         columns.1 = newValue
       case 2:
         columns.2 = newValue
+      default:
+        fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
+      }
+    }
+    _modify {
+      precondition(Self.columnIndexRange.contains(columnIndex))
+      switch columnIndex {
+      case 0:
+        yield &columns.0
+      case 1:
+        yield &columns.1
+      case 2:
+        yield &columns.2
       default:
         fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
       }
@@ -455,6 +479,21 @@ public extension MatrixDefaultSupportProtocol
         columns.2 = newValue
       case 3:
         columns.3 = newValue
+      default:
+        fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
+      }
+    }
+    _modify {
+      precondition(Self.columnIndexRange.contains(columnIndex))
+      switch columnIndex {
+      case 0:
+        yield &columns.0
+      case 1:
+        yield &columns.1
+      case 2:
+        yield &columns.2
+      case 3:
+        yield &columns.3
       default:
         fatalError("Used invalid `columnIndex` \(columnIndex) to subscript \(String(reflecting: self))!")
       }

--- a/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quatd+QuaternionProtocol.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quatd+QuaternionProtocol.swift
@@ -203,8 +203,11 @@ extension simd_quatd : QuaternionProtocol {
     set {
       real = newValue
     }
+    _modify {
+      yield &real
+    }
   }
-  
+
   // we supply (rename):
   @inlinable
   public var imaginaryComponent: Vector3 {
@@ -213,6 +216,9 @@ extension simd_quatd : QuaternionProtocol {
     }
     set {
       imag = newValue
+    }
+    _modify {
+      yield &imag
     }
   }
   

--- a/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quatf+QuaternionProtocol.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quatf+QuaternionProtocol.swift
@@ -203,8 +203,11 @@ extension simd_quatf : QuaternionProtocol {
     set {
       real = newValue
     }
+    _modify {
+      yield &real
+    }
   }
-  
+
   // we supply (rename):
   @inlinable
   public var imaginaryComponent: Vector3 {
@@ -213,6 +216,9 @@ extension simd_quatf : QuaternionProtocol {
     }
     set {
       imag = newValue
+    }
+    _modify {
+      yield &imag
     }
   }
   

--- a/Sources/HDXLSIMDSupport/Quaternion/Passthrough/Passthrough+QuaternionProtocol.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/Passthrough/Passthrough+QuaternionProtocol.swift
@@ -249,8 +249,11 @@ public extension Passthrough where PassthroughValue:QuaternionProtocol {
     set {
       passthroughValue.realComponent = newValue
     }
+    _modify {
+      yield &passthroughValue.realComponent
+    }
   }
-  
+
   @inlinable
   var imaginaryComponent: PassthroughValue.Vector3 {
     get {
@@ -258,6 +261,9 @@ public extension Passthrough where PassthroughValue:QuaternionProtocol {
     }
     set {
       passthroughValue.imaginaryComponent = newValue
+    }
+    _modify {
+      yield &passthroughValue.imaginaryComponent
     }
   }
   

--- a/Sources/HDXLSIMDSupport/Quaternion/Quaternion/Quaternion.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/Quaternion/Quaternion.swift
@@ -43,6 +43,9 @@ public struct Quaternion<Scalar:ExtendedSIMDScalar> :
     set {
       passthroughValue.passthroughValue = newValue
     }
+    _modify {
+      yield &passthroughValue.passthroughValue
+    }
   }
   
   @inlinable


### PR DESCRIPTION
## Summary

Adds `_modify` coroutine accessors to the computed properties and subscripts that forward through the `Matrix*<Scalar>` / `Quaternion<Scalar>` → `*Storage` → native `simd_*` hierarchy. Where the wrapper chain bottoms out in stored properties, the new accessors let the compiler project directly into the underlying SIMD value, so `get`-modify-`set` patterns (including in generic protocol-constrained code, since Swift's mutable witness ABI includes a `_modify` slot for `{ get set }` requirements) avoid the round-trip copy.

Covered: `nativeSIMDRepresentation` on the nine `MatrixMxN` wrappers and `Quaternion`; `var columns` and all five subscripts in `Passthrough+MatrixProtocol`; `realComponent` / `imaginaryComponent` in both `Passthrough+QuaternionProtocol` and `simd_quat{d,f}+QuaternionProtocol`; and the `MatrixDefaultSupportProtocol` scalar subscripts (`linearizedScalarIndex`, `position`, `columnIndex:rowIndex:`) and `T2`/`T3`/`T4` `columnIndex` subscripts (which yield `&columns.N` directly per branch).

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 77/77 pass