### PR TITLE
Add Float16 support to ExtendedSIMDScalar

### DIFF
--- a/Sources/HDXLSIMDSupport/ExtendedSIMDScalar/Float16+ExtendedSIMDScalar.swift
+++ b/Sources/HDXLSIMDSupport/ExtendedSIMDScalar/Float16+ExtendedSIMDScalar.swift
@@ -1,0 +1,22 @@
+//
+//  Float16+ExtendedSIMDScalar.swift
+//
+
+import Foundation
+import simd
+
+extension Float16 : ExtendedSIMDScalar {
+
+  public typealias QuaternionStorage = HalfQuaternionStorage
+
+  public typealias Matrix2x2Storage = HalfMatrix2x2Storage
+  public typealias Matrix2x3Storage = HalfMatrix2x3Storage
+  public typealias Matrix2x4Storage = HalfMatrix2x4Storage
+  public typealias Matrix3x2Storage = HalfMatrix3x2Storage
+  public typealias Matrix3x3Storage = HalfMatrix3x3Storage
+  public typealias Matrix3x4Storage = HalfMatrix3x4Storage
+  public typealias Matrix4x2Storage = HalfMatrix4x2Storage
+  public typealias Matrix4x3Storage = HalfMatrix4x3Storage
+  public typealias Matrix4x4Storage = HalfMatrix4x4Storage
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x2+Matrix2x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x2+Matrix2x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double2x2 : MatrixDefaultSupportProtocol, Matrix2x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x3+Matrix2x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x3+Matrix2x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double2x3 : MatrixDefaultSupportProtocol, Matrix2x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x4+Matrix2x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double2x4+Matrix2x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double2x4 : MatrixDefaultSupportProtocol, Matrix2x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x2+Matrix3x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x2+Matrix3x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double3x2 : MatrixDefaultSupportProtocol, Matrix3x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x3+Matrix3x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x3+Matrix3x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double3x3 : MatrixDefaultSupportProtocol, Matrix3x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x4+Matrix3x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double3x4+Matrix3x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double3x4 : MatrixDefaultSupportProtocol, Matrix3x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x2+Matrix4x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x2+Matrix4x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double4x2 : MatrixDefaultSupportProtocol, Matrix4x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x3+Matrix4x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x3+Matrix4x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double4x3 : MatrixDefaultSupportProtocol, Matrix4x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x4+Matrix4x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Double/simd_double4x4+Matrix4x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_double4x4 : MatrixDefaultSupportProtocol, Matrix4x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_doubleNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x2+Matrix2x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x2+Matrix2x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float2x2 : MatrixDefaultSupportProtocol, Matrix2x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x3+Matrix2x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x3+Matrix2x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float2x3 : MatrixDefaultSupportProtocol, Matrix2x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x4+Matrix2x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float2x4+Matrix2x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float2x4 : MatrixDefaultSupportProtocol, Matrix2x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x2+Matrix3x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x2+Matrix3x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float3x2 : MatrixDefaultSupportProtocol, Matrix3x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x3+Matrix3x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x3+Matrix3x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float3x3 : MatrixDefaultSupportProtocol, Matrix3x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x4+Matrix3x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float3x4+Matrix3x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float3x4 : MatrixDefaultSupportProtocol, Matrix3x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x2+Matrix4x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x2+Matrix4x2Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float4x2 : MatrixDefaultSupportProtocol, Matrix4x2Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x3+Matrix4x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x3+Matrix4x3Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float4x3 : MatrixDefaultSupportProtocol, Matrix4x3Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x4+Matrix4x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Float/simd_float4x4+Matrix4x4Protocol.swift
@@ -48,10 +48,13 @@ extension simd_float4x4 : MatrixDefaultSupportProtocol, Matrix4x4Protocol {
   // should already exist:
   // init()
   
-  // we supply (for now)
+  // The bridged `simd_floatNxM.init(_ scalar:)` constructor is a *diagonal*
+  // initializer (scalar on the diagonal, zeros elsewhere), so we cannot use it
+  // to satisfy the protocol's "all entries" contract for `init(repeating:)`.
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(scalar)
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
   
   // should already exist:

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/HalfNativeMatrices+Equatable.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/HalfNativeMatrices+Equatable.swift
@@ -1,0 +1,76 @@
+//
+//  HalfNativeMatrices+Equatable.swift
+//
+
+import Foundation
+import simd
+
+// `simd_floatNxM` and `simd_doubleNxM` are `Equatable` via the Swift overlay;
+// the half-precision variants are not yet bridged that way as of macOS 26.
+// The `Passthrough+Equatable` default in this package relies on
+// `PassthroughValue: Equatable`, so we add explicit conformances here to keep
+// the half-precision storages on the same shape as their Float/Double peers.
+// If/when the Swift overlay starts bridging this itself, these can be removed.
+
+extension simd_half2x2 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half2x2, rhs: simd_half2x2) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half2x3 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half2x3, rhs: simd_half2x3) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half2x4 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half2x4, rhs: simd_half2x4) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half3x2 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half3x2, rhs: simd_half3x2) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half3x3 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half3x3, rhs: simd_half3x3) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half3x4 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half3x4, rhs: simd_half3x4) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half4x2 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half4x2, rhs: simd_half4x2) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half4x3 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half4x3, rhs: simd_half4x3) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}
+
+extension simd_half4x4 : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_half4x4, rhs: simd_half4x4) -> Bool {
+    return lhs.columns == rhs.columns
+  }
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x2+Matrix2x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x2+Matrix2x2Protocol.swift
@@ -1,0 +1,435 @@
+//
+//  simd_half2x2+Matrix2x2Protocol.swift
+//
+
+import Foundation
+import simd
+
+// The matrix wrappers for half-precision route through the C `simd_*` family
+// rather than Swift-bridged conveniences and operators (which exist for
+// `simd_float*x*`/`simd_double*x*` but not yet for `simd_half*x*`).
+//
+// Constructors (`init(diagonal:)`, varargs columns, scalar broadcast) are
+// likewise unbridged for `simd_half*x*`, so we hand-build them from
+// `init(columns:)`.
+
+extension simd_half2x2 : MatrixDefaultSupportProtocol, Matrix2x2Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias ColumnVector = SIMD2<Scalar>
+  public typealias RowVector = SIMD2<Scalar>
+  public typealias DiagonalVector = SIMD2<Scalar>
+
+  public typealias Columns = T2<ColumnVector>
+  public typealias Rows = T2<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0),
+        ColumnVector(0, diagonal.y)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector
+  ) {
+    self.init(columns: (c0, c1))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half2x2.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half2x2,
+    weight firstWeight: Scalar,
+    with other: simd_half2x2,
+    weight otherWeight: Scalar
+  ) -> simd_half2x2 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half2x2.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half2x2.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half2x2.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0]),
+        RowVector(columns.0[1], columns.1[1])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x2,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x2,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half2x2 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half2x2) -> simd_half2x2 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half2x2) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half2x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x2 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half2x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half2x2) -> simd_half2x2 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half2x2) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half2x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x2 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half2x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half2x2 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half2x2 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleQuaternion = simd_quath
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Determinants
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var determinant: Scalar {
+    get {
+      return simd_determinant(self)
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Inversion
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func inverted() -> simd_half2x2 {
+    return simd_inverse(self)
+  }
+
+  @inlinable
+  public mutating func formInverse() {
+    self = simd_inverse(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: simd_half2x2) -> simd_half2x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: simd_half2x2) -> simd_half2x2 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: simd_half2x2) {
+    self = simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: simd_half2x2) {
+    self = simd_mul(lhs, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(onRightBy rhs: simd_half2x2) -> simd_half2x2 {
+    return simd_mul(self, simd_inverse(rhs))
+  }
+
+  @inlinable
+  public func divided(onLeftBy lhs: simd_half2x2) -> simd_half2x2 {
+    return simd_mul(simd_inverse(lhs), self)
+  }
+
+  @inlinable
+  public mutating func formDivision(onRightBy rhs: simd_half2x2) {
+    self = simd_mul(self, simd_inverse(rhs))
+  }
+
+  @inlinable
+  public mutating func formDivision(onLeftBy lhs: simd_half2x2) {
+    self = simd_mul(simd_inverse(lhs), self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half2x2 {
+    return simd_transpose(self)
+  }
+
+  @inlinable
+  public mutating func formTranspose() {
+    self = simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x2) -> CompatibleMatrix3x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x2) -> CompatibleMatrix4x2 {
+    return simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // `simd_mul(simd_half2x3, simd_half2x2) -> simd_half2x3`: the C function is
+  // correct but the Swift overlay miscomputes the return value when the
+  // result is a half3-row matrix (any `simd_halfNx3`). We synthesize the
+  // product column-by-column from SIMD3<Float16> arithmetic, which works.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x3) -> CompatibleMatrix2x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    return CompatibleMatrix2x3(
+      columns: (
+        l0 * columns.0[0] + l1 * columns.0[1],
+        l0 * columns.1[0] + l1 * columns.1[1]
+      )
+    )
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x4) -> CompatibleMatrix2x4 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x2+Matrix2x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x2+Matrix2x2Protocol.swift
@@ -30,7 +30,8 @@ extension simd_half2x2 : MatrixDefaultSupportProtocol, Matrix2x2Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x3+Matrix2x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x3+Matrix2x3Protocol.swift
@@ -1,0 +1,448 @@
+//
+//  simd_half2x3+Matrix2x3Protocol.swift
+//
+
+import Foundation
+import simd
+
+// `simd_half2x3` is a 2-column, 3-row matrix whose columns are
+// `SIMD3<Float16>`. The Swift overlay (as of macOS 26) miscomputes the return
+// values of C-level `simd_*` operations that produce any `simd_halfNx3`, so
+// every matrix-returning operation that lands on a half3-row shape is
+// implemented in pure Swift below. Operations whose result is a scalar,
+// bool, vector, or a non-half3-row matrix (e.g. `transpose -> simd_half3x2`)
+// still route through the C functions, which work correctly.
+
+extension simd_half2x3 : MatrixDefaultSupportProtocol, Matrix2x3Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD2<Scalar>
+  public typealias ColumnVector = SIMD3<Scalar>
+  public typealias DiagonalVector = SIMD2<Scalar>
+
+  public typealias Columns = T2<ColumnVector>
+  public typealias Rows = T3<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0),
+        ColumnVector(0, diagonal.y, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector
+  ) {
+    self.init(columns: (c0, c1))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(columns: (columnVectors[0], columnVectors[1]))
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half2x3.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half2x3,
+    weight firstWeight: Scalar,
+    with other: simd_half2x3,
+    weight otherWeight: Scalar
+  ) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        first.columns.0 * firstWeight + other.columns.0 * otherWeight,
+        first.columns.1 * firstWeight + other.columns.1 * otherWeight
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half2x3.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half2x3.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half2x3.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0]),
+        RowVector(columns.0[1], columns.1[1]),
+        RowVector(columns.0[2], columns.1[2])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x3,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x3,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half2x3 {
+    return simd_half2x3(columns: (-columns.0, -columns.1))
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    columns = (-columns.0, -columns.1)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half2x3) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        columns.0 + other.columns.0,
+        columns.1 + other.columns.1
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half2x3) {
+    columns = (
+      columns.0 + other.columns.0,
+      columns.1 + other.columns.1
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half2x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        columns.0 + other.columns.0 * scalar,
+        columns.1 + other.columns.1 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half2x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 + other.columns.0 * scalar,
+      columns.1 + other.columns.1 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half2x3) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        columns.0 - other.columns.0,
+        columns.1 - other.columns.1
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half2x3) {
+    columns = (
+      columns.0 - other.columns.0,
+      columns.1 - other.columns.1
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half2x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        columns.0 - other.columns.0 * scalar,
+        columns.1 - other.columns.1 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half2x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 - other.columns.0 * scalar,
+      columns.1 - other.columns.1 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        columns.0 * scalar,
+        columns.1 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    columns = (columns.0 * scalar, columns.1 * scalar)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half2x3 {
+    let inv = (1 as Scalar) / scalar
+    return simd_half2x3(
+      columns: (
+        columns.0 * inv,
+        columns.1 * inv
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    let inv = (1 as Scalar) / scalar
+    columns = (columns.0 * inv, columns.1 * inv)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix2x2 = simd_half2x2
+  public typealias CompatibleMatrix3x3 = simd_half3x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  // Result is `simd_half3x2` (SIMD2 columns), so the C function works.
+  @inlinable
+  public func transposed() -> simd_half3x2 {
+    return simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // self * rhs (2x2): result is half2x3 (broken); compute column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x2) -> simd_half2x3 {
+    let c0 = columns.0
+    let c1 = columns.1
+    return simd_half2x3(
+      columns: (
+        c0 * rhs.columns.0[0] + c1 * rhs.columns.0[1],
+        c0 * rhs.columns.1[0] + c1 * rhs.columns.1[1]
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix2x2) {
+    self = multiplied(onRightBy: rhs)
+  }
+
+  // self * rhs (3x2): result is half3x3 (broken); compute column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x2) -> CompatibleMatrix3x3 {
+    let c0 = columns.0
+    let c1 = columns.1
+    return CompatibleMatrix3x3(
+      columns: (
+        c0 * rhs.columns.0[0] + c1 * rhs.columns.0[1],
+        c0 * rhs.columns.1[0] + c1 * rhs.columns.1[1],
+        c0 * rhs.columns.2[0] + c1 * rhs.columns.2[1]
+      )
+    )
+  }
+
+  // self * rhs (4x2): result is half4x3 (broken); compute column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x2) -> CompatibleMatrix4x3 {
+    let c0 = columns.0
+    let c1 = columns.1
+    return CompatibleMatrix4x3(
+      columns: (
+        c0 * rhs.columns.0[0] + c1 * rhs.columns.0[1],
+        c0 * rhs.columns.1[0] + c1 * rhs.columns.1[1],
+        c0 * rhs.columns.2[0] + c1 * rhs.columns.2[1],
+        c0 * rhs.columns.3[0] + c1 * rhs.columns.3[1]
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // lhs (3x2) * self: result is half2x2 (SIMD2 cols), so the C function
+  // works correctly.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x2) -> CompatibleMatrix2x2 {
+    return simd_mul(lhs, self)
+  }
+
+  // lhs (3x3) * self: result is half2x3 (broken); compute column-wise.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x3) -> simd_half2x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    let l2 = lhs.columns.2
+    return simd_half2x3(
+      columns: (
+        l0 * columns.0[0] + l1 * columns.0[1] + l2 * columns.0[2],
+        l0 * columns.1[0] + l1 * columns.1[1] + l2 * columns.1[2]
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix3x3) {
+    self = multiplied(onLeftBy: lhs)
+  }
+
+  // lhs (3x4) * self: result is half2x4 (SIMD4 cols), so the C function works.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x4) -> CompatibleMatrix2x4 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x3+Matrix2x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x3+Matrix2x3Protocol.swift
@@ -30,7 +30,8 @@ extension simd_half2x3 : MatrixDefaultSupportProtocol, Matrix2x3Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x4+Matrix2x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x4+Matrix2x4Protocol.swift
@@ -1,0 +1,374 @@
+//
+//  simd_half2x4+Matrix2x4Protocol.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half2x4 : MatrixDefaultSupportProtocol, Matrix2x4Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD2<Scalar>
+  public typealias ColumnVector = SIMD4<Scalar>
+  public typealias DiagonalVector = SIMD2<Scalar>
+
+  public typealias Columns = T2<ColumnVector>
+  public typealias Rows = T4<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0, 0),
+        ColumnVector(0, diagonal.y, 0, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector
+  ) {
+    self.init(columns: (c0, c1))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2], rowVectors[3]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half2x4.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half2x4,
+    weight firstWeight: Scalar,
+    with other: simd_half2x4,
+    weight otherWeight: Scalar
+  ) -> simd_half2x4 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half2x4.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half2x4.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half2x4.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0]),
+        RowVector(columns.0[1], columns.1[1]),
+        RowVector(columns.0[2], columns.1[2]),
+        RowVector(columns.0[3], columns.1[3])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x4,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half2x4,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half2x4 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half2x4) -> simd_half2x4 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half2x4) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half2x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x4 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half2x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half2x4) -> simd_half2x4 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half2x4) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half2x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half2x4 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half2x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half2x4 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half2x4 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix2x2 = simd_half2x2
+  public typealias CompatibleMatrix4x4 = simd_half4x4
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half4x2 {
+    return simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x2) -> simd_half2x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix2x2) {
+    self = simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x2) -> CompatibleMatrix3x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x2) -> CompatibleMatrix4x4 {
+    return simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x2) -> CompatibleMatrix2x2 {
+    return simd_mul(lhs, self)
+  }
+
+  // `simd_mul(simd_half4x3, simd_half2x4) -> simd_half2x3`: the result is a
+  // half3-row shape; build it column-by-column.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x3) -> CompatibleMatrix2x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    let l2 = lhs.columns.2
+    let l3 = lhs.columns.3
+    let s0 = columns.0
+    let s1 = columns.1
+    let rc0_a: SIMD3<Scalar> = l0 * s0[0] + l1 * s0[1]
+    let rc0_b: SIMD3<Scalar> = l2 * s0[2] + l3 * s0[3]
+    let rc1_a: SIMD3<Scalar> = l0 * s1[0] + l1 * s1[1]
+    let rc1_b: SIMD3<Scalar> = l2 * s1[2] + l3 * s1[3]
+    return CompatibleMatrix2x3(columns: (rc0_a + rc0_b, rc1_a + rc1_b))
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x4) -> simd_half2x4 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix4x4) {
+    self = simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x4+Matrix2x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half2x4+Matrix2x4Protocol.swift
@@ -22,7 +22,8 @@ extension simd_half2x4 : MatrixDefaultSupportProtocol, Matrix2x4Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x2+Matrix3x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x2+Matrix3x2Protocol.swift
@@ -22,7 +22,8 @@ extension simd_half3x2 : MatrixDefaultSupportProtocol, Matrix3x2Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x2+Matrix3x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x2+Matrix3x2Protocol.swift
@@ -1,0 +1,388 @@
+//
+//  simd_half3x2+Matrix3x2Protocol.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half3x2 : MatrixDefaultSupportProtocol, Matrix3x2Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD3<Scalar>
+  public typealias ColumnVector = SIMD2<Scalar>
+  public typealias DiagonalVector = SIMD2<Scalar>
+
+  public typealias Columns = T3<ColumnVector>
+  public typealias Rows = T2<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0),
+        ColumnVector(0, diagonal.y),
+        ColumnVector(0, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1],
+        columnVectors[2]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half3x2.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half3x2,
+    weight firstWeight: Scalar,
+    with other: simd_half3x2,
+    weight otherWeight: Scalar
+  ) -> simd_half3x2 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half3x2.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half3x2.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half3x2.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x2,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x2,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half3x2 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half3x2) -> simd_half3x2 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half3x2) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half3x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x2 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half3x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half3x2) -> simd_half3x2 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half3x2) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half3x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x2 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half3x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half3x2 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half3x2 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix2x2 = simd_half2x2
+  public typealias CompatibleMatrix3x3 = simd_half3x3
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  // `simd_transpose(simd_half3x2) -> simd_half2x3`: result is a half3-row
+  // shape; build it column-by-column.
+  @inlinable
+  public func transposed() -> simd_half2x3 {
+    return simd_half2x3(
+      columns: (
+        SIMD3<Scalar>(columns.0[0], columns.1[0], columns.2[0]),
+        SIMD3<Scalar>(columns.0[1], columns.1[1], columns.2[1])
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x3) -> CompatibleMatrix2x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x3) -> simd_half3x2 {
+    // `simd_mul(simd_half3x2, simd_half3x3) -> simd_half3x2`: output is
+    // half3x2 (SIMD2 columns), not a half3-row shape, so the C function is
+    // usable directly.
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix3x3) {
+    self = simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x3) -> CompatibleMatrix4x2 {
+    return simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x2) -> simd_half3x2 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix2x2) {
+    self = simd_mul(lhs, self)
+  }
+
+  // `simd_mul(simd_half2x3, simd_half3x2) -> simd_half3x3`: the result is a
+  // half3-row shape, which the Swift overlay miscomputes. Build the product
+  // column-by-column from the individual SIMD3<Float16> columns.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x3) -> CompatibleMatrix3x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    return CompatibleMatrix3x3(
+      columns: (
+        l0 * columns.0[0] + l1 * columns.0[1],
+        l0 * columns.1[0] + l1 * columns.1[1],
+        l0 * columns.2[0] + l1 * columns.2[1]
+      )
+    )
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x4) -> CompatibleMatrix3x4 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x3+Matrix3x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x3+Matrix3x3Protocol.swift
@@ -30,7 +30,8 @@ extension simd_half3x3 : MatrixDefaultSupportProtocol, Matrix3x3Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x3+Matrix3x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x3+Matrix3x3Protocol.swift
@@ -1,0 +1,562 @@
+//
+//  simd_half3x3+Matrix3x3Protocol.swift
+//
+
+import Foundation
+import simd
+
+// `simd_half3x3` is a 3-column, 3-row matrix whose columns are
+// `SIMD3<Float16>`. The Swift overlay (as of macOS 26) miscomputes the return
+// values of C-level `simd_*` operations that produce any `simd_halfNx3`, so
+// every matrix-returning operation that lands on a half3-row shape is
+// implemented in pure Swift below. Operations whose result is a scalar,
+// bool, vector, or a non-half3-row matrix still route through the C
+// functions, which work correctly.
+
+extension simd_half3x3 : MatrixDefaultSupportProtocol, Matrix3x3Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias ColumnVector = SIMD3<Scalar>
+  public typealias RowVector = SIMD3<Scalar>
+  public typealias DiagonalVector = SIMD3<Scalar>
+
+  public typealias Columns = T3<ColumnVector>
+  public typealias Rows = T3<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0),
+        ColumnVector(0, diagonal.y, 0),
+        ColumnVector(0, 0, diagonal.z)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(columns: (columnVectors[0], columnVectors[1], columnVectors[2]))
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half3x3.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half3x3,
+    weight firstWeight: Scalar,
+    with other: simd_half3x3,
+    weight otherWeight: Scalar
+  ) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        first.columns.0 * firstWeight + other.columns.0 * otherWeight,
+        first.columns.1 * firstWeight + other.columns.1 * otherWeight,
+        first.columns.2 * firstWeight + other.columns.2 * otherWeight
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half3x3.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half3x3.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half3x3.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1]),
+        RowVector(columns.0[2], columns.1[2], columns.2[2])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x3,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x3,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half3x3 {
+    return simd_half3x3(columns: (-columns.0, -columns.1, -columns.2))
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    columns = (-columns.0, -columns.1, -columns.2)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half3x3) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        columns.0 + other.columns.0,
+        columns.1 + other.columns.1,
+        columns.2 + other.columns.2
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half3x3) {
+    columns = (
+      columns.0 + other.columns.0,
+      columns.1 + other.columns.1,
+      columns.2 + other.columns.2
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half3x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        columns.0 + other.columns.0 * scalar,
+        columns.1 + other.columns.1 * scalar,
+        columns.2 + other.columns.2 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half3x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 + other.columns.0 * scalar,
+      columns.1 + other.columns.1 * scalar,
+      columns.2 + other.columns.2 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half3x3) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        columns.0 - other.columns.0,
+        columns.1 - other.columns.1,
+        columns.2 - other.columns.2
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half3x3) {
+    columns = (
+      columns.0 - other.columns.0,
+      columns.1 - other.columns.1,
+      columns.2 - other.columns.2
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half3x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        columns.0 - other.columns.0 * scalar,
+        columns.1 - other.columns.1 * scalar,
+        columns.2 - other.columns.2 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half3x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 - other.columns.0 * scalar,
+      columns.1 - other.columns.1 * scalar,
+      columns.2 - other.columns.2 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        columns.0 * scalar,
+        columns.1 * scalar,
+        columns.2 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    columns = (columns.0 * scalar, columns.1 * scalar, columns.2 * scalar)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half3x3 {
+    let inv = (1 as Scalar) / scalar
+    return simd_half3x3(
+      columns: (
+        columns.0 * inv,
+        columns.1 * inv,
+        columns.2 * inv
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    let inv = (1 as Scalar) / scalar
+    columns = (columns.0 * inv, columns.1 * inv, columns.2 * inv)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleQuaternion = simd_quath
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization From Quaternion
+  // ------------------------------------------------------------------------ //
+
+  // `simd_matrix3x3(simd_quath)` is buggy in macOS 26 (columns are scrambled
+  // when the result crosses the Swift overlay). The 4x4 form is correct, so
+  // we obtain the rotation matrix from `simd_matrix4x4` and extract its
+  // upper-left 3x3 submatrix.
+  @inlinable
+  public init(quaternion: CompatibleQuaternion) {
+    let m4 = simd_matrix4x4(quaternion)
+    self.init(
+      columns: (
+        SIMD3<Scalar>(m4.columns.0.x, m4.columns.0.y, m4.columns.0.z),
+        SIMD3<Scalar>(m4.columns.1.x, m4.columns.1.y, m4.columns.1.z),
+        SIMD3<Scalar>(m4.columns.2.x, m4.columns.2.y, m4.columns.2.z)
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Determinants
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var determinant: Scalar {
+    get {
+      return simd_determinant(self)
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Inversion
+  // ------------------------------------------------------------------------ //
+
+  // Compute the inverse via the cross-product formula:
+  // ```
+  //   M^-1 = (1/det) · | (c1 × c2)^T |
+  //                    | (c2 × c0)^T |
+  //                    | (c0 × c1)^T |
+  // ```
+  // where `c0`/`c1`/`c2` are the columns of M. We can't use
+  // `simd_inverse(simd_half3x3)` because the return crosses the broken
+  // half3-row Swift bridge.
+  @inlinable
+  public func inverted() -> simd_half3x3 {
+    let c0 = columns.0
+    let c1 = columns.1
+    let c2 = columns.2
+    let det = simd_determinant(self)
+    let invDet = (1 as Scalar) / det
+    let r0 = simd_cross(c1, c2)
+    let r1 = simd_cross(c2, c0)
+    let r2 = simd_cross(c0, c1)
+    return simd_half3x3(
+      columns: (
+        SIMD3<Scalar>(r0[0], r1[0], r2[0]) * invDet,
+        SIMD3<Scalar>(r0[1], r1[1], r2[1]) * invDet,
+        SIMD3<Scalar>(r0[2], r1[2], r2[2]) * invDet
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formInverse() {
+    self = inverted()
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // self * rhs: build the product column-by-column from the columns of self.
+  @inlinable
+  public func multiplied(onRightBy rhs: simd_half3x3) -> simd_half3x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    return simd_half3x3(
+      columns: (
+        s0 * rhs.columns.0[0] + s1 * rhs.columns.0[1] + s2 * rhs.columns.0[2],
+        s0 * rhs.columns.1[0] + s1 * rhs.columns.1[1] + s2 * rhs.columns.1[2],
+        s0 * rhs.columns.2[0] + s1 * rhs.columns.2[1] + s2 * rhs.columns.2[2]
+      )
+    )
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: simd_half3x3) -> simd_half3x3 {
+    return lhs.multiplied(onRightBy: self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: simd_half3x3) {
+    self = multiplied(onRightBy: rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: simd_half3x3) {
+    self = lhs.multiplied(onRightBy: self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(onRightBy rhs: simd_half3x3) -> simd_half3x3 {
+    return multiplied(onRightBy: rhs.inverted())
+  }
+
+  @inlinable
+  public func divided(onLeftBy lhs: simd_half3x3) -> simd_half3x3 {
+    return lhs.inverted().multiplied(onRightBy: self)
+  }
+
+  @inlinable
+  public mutating func formDivision(onRightBy rhs: simd_half3x3) {
+    self = divided(onRightBy: rhs)
+  }
+
+  @inlinable
+  public mutating func formDivision(onLeftBy lhs: simd_half3x3) {
+    self = lhs.inverted().multiplied(onRightBy: self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half3x3 {
+    return simd_half3x3(
+      columns: (
+        SIMD3<Scalar>(columns.0[0], columns.1[0], columns.2[0]),
+        SIMD3<Scalar>(columns.0[1], columns.1[1], columns.2[1]),
+        SIMD3<Scalar>(columns.0[2], columns.1[2], columns.2[2])
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formTranspose() {
+    self = transposed()
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // self (3x3) * rhs (2x3) -> 2x3 (broken): build column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x3) -> CompatibleMatrix2x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    return CompatibleMatrix2x3(
+      columns: (
+        s0 * rhs.columns.0[0] + s1 * rhs.columns.0[1] + s2 * rhs.columns.0[2],
+        s0 * rhs.columns.1[0] + s1 * rhs.columns.1[1] + s2 * rhs.columns.1[2]
+      )
+    )
+  }
+
+  // self (3x3) * rhs (4x3) -> 4x3 (broken): build column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x3) -> CompatibleMatrix4x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    return CompatibleMatrix4x3(
+      columns: (
+        s0 * rhs.columns.0[0] + s1 * rhs.columns.0[1] + s2 * rhs.columns.0[2],
+        s0 * rhs.columns.1[0] + s1 * rhs.columns.1[1] + s2 * rhs.columns.1[2],
+        s0 * rhs.columns.2[0] + s1 * rhs.columns.2[1] + s2 * rhs.columns.2[2],
+        s0 * rhs.columns.3[0] + s1 * rhs.columns.3[1] + s2 * rhs.columns.3[2]
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // lhs (3x2) * self (3x3) -> half3x2 (SIMD2 cols, OK).
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x2) -> CompatibleMatrix3x2 {
+    return simd_mul(lhs, self)
+  }
+
+  // lhs (3x4) * self (3x3) -> half3x4 (SIMD4 cols, OK).
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x4) -> CompatibleMatrix3x4 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x4+Matrix3x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x4+Matrix3x4Protocol.swift
@@ -22,7 +22,8 @@ extension simd_half3x4 : MatrixDefaultSupportProtocol, Matrix3x4Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x4+Matrix3x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half3x4+Matrix3x4Protocol.swift
@@ -1,0 +1,395 @@
+//
+//  simd_half3x4+Matrix3x4Protocol.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half3x4 : MatrixDefaultSupportProtocol, Matrix3x4Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD3<Scalar>
+  public typealias ColumnVector = SIMD4<Scalar>
+  public typealias DiagonalVector = SIMD3<Scalar>
+
+  public typealias Columns = T3<ColumnVector>
+  public typealias Rows = T4<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0, 0),
+        ColumnVector(0, diagonal.y, 0, 0),
+        ColumnVector(0, 0, diagonal.z, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1],
+        columnVectors[2]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2], rowVectors[3]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half3x4.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half3x4,
+    weight firstWeight: Scalar,
+    with other: simd_half3x4,
+    weight otherWeight: Scalar
+  ) -> simd_half3x4 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half3x4.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half3x4.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half3x4.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1]),
+        RowVector(columns.0[2], columns.1[2], columns.2[2]),
+        RowVector(columns.0[3], columns.1[3], columns.2[3])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x4,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half3x4,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half3x4 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half3x4) -> simd_half3x4 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half3x4) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half3x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x4 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half3x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half3x4) -> simd_half3x4 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half3x4) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half3x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half3x4 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half3x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half3x4 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half3x4 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix4x4 = simd_half4x4
+  public typealias CompatibleMatrix3x3 = simd_half3x3
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half4x3 {
+    // `simd_transpose(simd_half3x4) -> simd_half4x3`: result is a half3-row
+    // shape; build it column-by-column.
+    return simd_half4x3(
+      columns: (
+        SIMD3<Scalar>(columns.0[0], columns.1[0], columns.2[0]),
+        SIMD3<Scalar>(columns.0[1], columns.1[1], columns.2[1]),
+        SIMD3<Scalar>(columns.0[2], columns.1[2], columns.2[2]),
+        SIMD3<Scalar>(columns.0[3], columns.1[3], columns.2[3])
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x3) -> CompatibleMatrix2x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x3) -> simd_half3x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix3x3) {
+    self = simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x3) -> CompatibleMatrix4x4 {
+    return simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x2) -> CompatibleMatrix3x2 {
+    return simd_mul(lhs, self)
+  }
+
+  // `simd_mul(simd_half4x3, simd_half3x4) -> simd_half3x3`: the result is a
+  // half3-row shape; build it column-by-column.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x3) -> CompatibleMatrix3x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    let l2 = lhs.columns.2
+    let l3 = lhs.columns.3
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    let rc0_a: SIMD3<Scalar> = l0 * s0[0] + l1 * s0[1]
+    let rc0_b: SIMD3<Scalar> = l2 * s0[2] + l3 * s0[3]
+    let rc1_a: SIMD3<Scalar> = l0 * s1[0] + l1 * s1[1]
+    let rc1_b: SIMD3<Scalar> = l2 * s1[2] + l3 * s1[3]
+    let rc2_a: SIMD3<Scalar> = l0 * s2[0] + l1 * s2[1]
+    let rc2_b: SIMD3<Scalar> = l2 * s2[2] + l3 * s2[3]
+    return CompatibleMatrix3x3(
+      columns: (rc0_a + rc0_b, rc1_a + rc1_b, rc2_a + rc2_b)
+    )
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x4) -> simd_half3x4 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix4x4) {
+    self = simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x2+Matrix4x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x2+Matrix4x2Protocol.swift
@@ -22,7 +22,8 @@ extension simd_half4x2 : MatrixDefaultSupportProtocol, Matrix4x2Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x2+Matrix4x2Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x2+Matrix4x2Protocol.swift
@@ -1,0 +1,386 @@
+//
+//  simd_half4x2+Matrix4x2Protocol.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half4x2 : MatrixDefaultSupportProtocol, Matrix4x2Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD4<Scalar>
+  public typealias ColumnVector = SIMD2<Scalar>
+  public typealias DiagonalVector = SIMD2<Scalar>
+
+  public typealias Columns = T4<ColumnVector>
+  public typealias Rows = T2<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0),
+        ColumnVector(0, diagonal.y),
+        ColumnVector(0, 0),
+        ColumnVector(0, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector,
+    _ c3: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2, c3))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1],
+        columnVectors[2],
+        columnVectors[3]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half4x2.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half4x2,
+    weight firstWeight: Scalar,
+    with other: simd_half4x2,
+    weight otherWeight: Scalar
+  ) -> simd_half4x2 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half4x2.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex],
+        columns.3[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half4x2.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+      columns.3[rowIndex] = newValue[3]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half4x2.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0], columns.3[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1], columns.3[1])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x2,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x2,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+        +
+        simd_length_squared(columns.3)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half4x2 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half4x2) -> simd_half4x2 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half4x2) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half4x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x2 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half4x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half4x2) -> simd_half4x2 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half4x2) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half4x2,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x2 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half4x2,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half4x2 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half4x2 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix4x4 = simd_half4x4
+  public typealias CompatibleMatrix2x2 = simd_half2x2
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half2x4 {
+    return simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x4) -> CompatibleMatrix2x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x4) -> CompatibleMatrix3x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x4) -> simd_half4x2 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix4x4) {
+    self = simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x2) -> simd_half4x2 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix2x2) {
+    self = simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x4) -> CompatibleMatrix4x4 {
+    return simd_mul(lhs, self)
+  }
+
+  // `simd_mul(simd_half2x3, simd_half4x2) -> simd_half4x3`: the result is a
+  // half3-row shape that the Swift overlay miscomputes. We build it column-
+  // by-column from SIMD3<Float16> arithmetic.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix2x3) -> CompatibleMatrix4x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    return CompatibleMatrix4x3(
+      columns: (
+        l0 * columns.0[0] + l1 * columns.0[1],
+        l0 * columns.1[0] + l1 * columns.1[1],
+        l0 * columns.2[0] + l1 * columns.2[1],
+        l0 * columns.3[0] + l1 * columns.3[1]
+      )
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x3+Matrix4x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x3+Matrix4x3Protocol.swift
@@ -30,7 +30,8 @@ extension simd_half4x3 : MatrixDefaultSupportProtocol, Matrix4x3Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x3+Matrix4x3Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x3+Matrix4x3Protocol.swift
@@ -1,0 +1,524 @@
+//
+//  simd_half4x3+Matrix4x3Protocol.swift
+//
+
+import Foundation
+import simd
+
+// `simd_half4x3` is a 4-column, 3-row matrix whose columns are
+// `SIMD3<Float16>`. The Swift overlay (as of macOS 26) miscomputes the return
+// values of C-level `simd_*` operations that produce any `simd_halfNx3`, so
+// every matrix-returning operation that lands on a half3-row shape is
+// implemented in pure Swift below. Operations whose result is a scalar,
+// bool, vector, or a non-half3-row matrix (e.g. `transpose -> simd_half3x4`)
+// still route through the C functions, which work correctly.
+
+extension simd_half4x3 : MatrixDefaultSupportProtocol, Matrix4x3Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias RowVector = SIMD4<Scalar>
+  public typealias ColumnVector = SIMD3<Scalar>
+  public typealias DiagonalVector = SIMD3<Scalar>
+
+  public typealias Columns = T4<ColumnVector>
+  public typealias Rows = T3<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0),
+        ColumnVector(0, diagonal.y, 0),
+        ColumnVector(0, 0, diagonal.z),
+        ColumnVector(0, 0, 0)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector,
+    _ c3: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2, c3))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1],
+        columnVectors[2],
+        columnVectors[3]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half4x3.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half4x3,
+    weight firstWeight: Scalar,
+    with other: simd_half4x3,
+    weight otherWeight: Scalar
+  ) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        first.columns.0 * firstWeight + other.columns.0 * otherWeight,
+        first.columns.1 * firstWeight + other.columns.1 * otherWeight,
+        first.columns.2 * firstWeight + other.columns.2 * otherWeight,
+        first.columns.3 * firstWeight + other.columns.3 * otherWeight
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half4x3.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex],
+        columns.3[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half4x3.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+      columns.3[rowIndex] = newValue[3]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half4x3.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0], columns.3[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1], columns.3[1]),
+        RowVector(columns.0[2], columns.1[2], columns.2[2], columns.3[2])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x3,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x3,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+        +
+        simd_length_squared(columns.3)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half4x3 {
+    return simd_half4x3(columns: (-columns.0, -columns.1, -columns.2, -columns.3))
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    columns = (-columns.0, -columns.1, -columns.2, -columns.3)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half4x3) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        columns.0 + other.columns.0,
+        columns.1 + other.columns.1,
+        columns.2 + other.columns.2,
+        columns.3 + other.columns.3
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half4x3) {
+    columns = (
+      columns.0 + other.columns.0,
+      columns.1 + other.columns.1,
+      columns.2 + other.columns.2,
+      columns.3 + other.columns.3
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half4x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        columns.0 + other.columns.0 * scalar,
+        columns.1 + other.columns.1 * scalar,
+        columns.2 + other.columns.2 * scalar,
+        columns.3 + other.columns.3 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half4x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 + other.columns.0 * scalar,
+      columns.1 + other.columns.1 * scalar,
+      columns.2 + other.columns.2 * scalar,
+      columns.3 + other.columns.3 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half4x3) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        columns.0 - other.columns.0,
+        columns.1 - other.columns.1,
+        columns.2 - other.columns.2,
+        columns.3 - other.columns.3
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half4x3) {
+    columns = (
+      columns.0 - other.columns.0,
+      columns.1 - other.columns.1,
+      columns.2 - other.columns.2,
+      columns.3 - other.columns.3
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half4x3,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        columns.0 - other.columns.0 * scalar,
+        columns.1 - other.columns.1 * scalar,
+        columns.2 - other.columns.2 * scalar,
+        columns.3 - other.columns.3 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half4x3,
+    multipliedBy scalar: Scalar
+  ) {
+    columns = (
+      columns.0 - other.columns.0 * scalar,
+      columns.1 - other.columns.1 * scalar,
+      columns.2 - other.columns.2 * scalar,
+      columns.3 - other.columns.3 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half4x3 {
+    return simd_half4x3(
+      columns: (
+        columns.0 * scalar,
+        columns.1 * scalar,
+        columns.2 * scalar,
+        columns.3 * scalar
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    columns = (
+      columns.0 * scalar,
+      columns.1 * scalar,
+      columns.2 * scalar,
+      columns.3 * scalar
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half4x3 {
+    let inv = (1 as Scalar) / scalar
+    return simd_half4x3(
+      columns: (
+        columns.0 * inv,
+        columns.1 * inv,
+        columns.2 * inv,
+        columns.3 * inv
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    let inv = (1 as Scalar) / scalar
+    columns = (
+      columns.0 * inv,
+      columns.1 * inv,
+      columns.2 * inv,
+      columns.3 * inv
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleMatrix4x4 = simd_half4x4
+  public typealias CompatibleMatrix3x3 = simd_half3x3
+  public typealias CompatibleMatrix2x3 = simd_half2x3
+  public typealias CompatibleMatrix3x2 = simd_half3x2
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  // Result is `simd_half3x4` (SIMD4 columns), so the C function works.
+  @inlinable
+  public func transposed() -> simd_half3x4 {
+    return simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // self (4x3) * rhs (2x4) -> 2x3 (broken): column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x4) -> CompatibleMatrix2x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    let s3 = columns.3
+    let r0 = rhs.columns.0
+    let r1 = rhs.columns.1
+    let rc0_a: SIMD3<Scalar> = s0 * r0[0] + s1 * r0[1]
+    let rc0_b: SIMD3<Scalar> = s2 * r0[2] + s3 * r0[3]
+    let rc1_a: SIMD3<Scalar> = s0 * r1[0] + s1 * r1[1]
+    let rc1_b: SIMD3<Scalar> = s2 * r1[2] + s3 * r1[3]
+    return CompatibleMatrix2x3(columns: (rc0_a + rc0_b, rc1_a + rc1_b))
+  }
+
+  // self (4x3) * rhs (3x4) -> 3x3 (broken): column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x4) -> CompatibleMatrix3x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    let s3 = columns.3
+    let r0 = rhs.columns.0
+    let r1 = rhs.columns.1
+    let r2 = rhs.columns.2
+    let rc0_a: SIMD3<Scalar> = s0 * r0[0] + s1 * r0[1]
+    let rc0_b: SIMD3<Scalar> = s2 * r0[2] + s3 * r0[3]
+    let rc1_a: SIMD3<Scalar> = s0 * r1[0] + s1 * r1[1]
+    let rc1_b: SIMD3<Scalar> = s2 * r1[2] + s3 * r1[3]
+    let rc2_a: SIMD3<Scalar> = s0 * r2[0] + s1 * r2[1]
+    let rc2_b: SIMD3<Scalar> = s2 * r2[2] + s3 * r2[3]
+    return CompatibleMatrix3x3(
+      columns: (rc0_a + rc0_b, rc1_a + rc1_b, rc2_a + rc2_b)
+    )
+  }
+
+  // self (4x3) * rhs (4x4) -> Self (half4x3, broken): column-wise.
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix4x4) -> simd_half4x3 {
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    let s3 = columns.3
+    let r0 = rhs.columns.0
+    let r1 = rhs.columns.1
+    let r2 = rhs.columns.2
+    let r3 = rhs.columns.3
+    let rc0_a: SIMD3<Scalar> = s0 * r0[0] + s1 * r0[1]
+    let rc0_b: SIMD3<Scalar> = s2 * r0[2] + s3 * r0[3]
+    let rc1_a: SIMD3<Scalar> = s0 * r1[0] + s1 * r1[1]
+    let rc1_b: SIMD3<Scalar> = s2 * r1[2] + s3 * r1[3]
+    let rc2_a: SIMD3<Scalar> = s0 * r2[0] + s1 * r2[1]
+    let rc2_b: SIMD3<Scalar> = s2 * r2[2] + s3 * r2[3]
+    let rc3_a: SIMD3<Scalar> = s0 * r3[0] + s1 * r3[1]
+    let rc3_b: SIMD3<Scalar> = s2 * r3[2] + s3 * r3[3]
+    return simd_half4x3(
+      columns: (
+        rc0_a + rc0_b,
+        rc1_a + rc1_b,
+        rc2_a + rc2_b,
+        rc3_a + rc3_b
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: CompatibleMatrix4x4) {
+    self = multiplied(onRightBy: rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left-Hand Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // lhs (3x2) * self (4x3) -> 4x2 (SIMD2 cols, OK).
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x2) -> CompatibleMatrix4x2 {
+    return simd_mul(lhs, self)
+  }
+
+  // lhs (3x3) * self (4x3) -> Self (half4x3, broken): column-wise.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x3) -> simd_half4x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    let l2 = lhs.columns.2
+    return simd_half4x3(
+      columns: (
+        l0 * columns.0[0] + l1 * columns.0[1] + l2 * columns.0[2],
+        l0 * columns.1[0] + l1 * columns.1[1] + l2 * columns.1[2],
+        l0 * columns.2[0] + l1 * columns.2[1] + l2 * columns.2[2],
+        l0 * columns.3[0] + l1 * columns.3[1] + l2 * columns.3[2]
+      )
+    )
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: CompatibleMatrix3x3) {
+    self = multiplied(onLeftBy: lhs)
+  }
+
+  // lhs (3x4) * self (4x3) -> 4x4 (SIMD4 cols, OK).
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix3x4) -> CompatibleMatrix4x4 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x4+Matrix4x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x4+Matrix4x4Protocol.swift
@@ -22,7 +22,8 @@ extension simd_half4x4 : MatrixDefaultSupportProtocol, Matrix4x4Protocol {
 
   @inlinable
   public init(repeating scalar: Scalar) {
-    self.init(diagonal: DiagonalVector(repeating: scalar))
+    let column = ColumnVector(repeating: scalar)
+    self.init(columns: (column, column, column, column))
   }
 
   @inlinable

--- a/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x4+Matrix4x4Protocol.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/NativeConformances/Half/simd_half4x4+Matrix4x4Protocol.swift
@@ -1,0 +1,468 @@
+//
+//  simd_half4x4+Matrix4x4Protocol.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half4x4 : MatrixDefaultSupportProtocol, Matrix4x4Protocol {
+
+  public typealias Scalar = Float16
+
+  public typealias ColumnVector = SIMD4<Scalar>
+  public typealias RowVector = SIMD4<Scalar>
+  public typealias DiagonalVector = SIMD4<Scalar>
+
+  public typealias Columns = T4<ColumnVector>
+  public typealias Rows = T4<RowVector>
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public init(repeating scalar: Scalar) {
+    self.init(diagonal: DiagonalVector(repeating: scalar))
+  }
+
+  @inlinable
+  public init(diagonal: DiagonalVector) {
+    self.init(
+      columns: (
+        ColumnVector(diagonal.x, 0, 0, 0),
+        ColumnVector(0, diagonal.y, 0, 0),
+        ColumnVector(0, 0, diagonal.z, 0),
+        ColumnVector(0, 0, 0, diagonal.w)
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    _ c0: ColumnVector,
+    _ c1: ColumnVector,
+    _ c2: ColumnVector,
+    _ c3: ColumnVector
+  ) {
+    self.init(columns: (c0, c1, c2, c3))
+  }
+
+  @inlinable
+  public init(columnVectors: [ColumnVector]) {
+    precondition(columnVectors.count == Self.columnCount)
+    self.init(
+      columns: (
+        columnVectors[0],
+        columnVectors[1],
+        columnVectors[2],
+        columnVectors[3]
+      )
+    )
+  }
+
+  @inlinable
+  public init(rowVectors: [RowVector]) {
+    precondition(rowVectors.count == Self.rowCount)
+    self.init(rows: (rowVectors[0], rowVectors[1], rowVectors[2], rowVectors[3]))
+  }
+
+  @inlinable
+  public init(linearizedScalars: [Scalar]) {
+    precondition(linearizedScalars.count == Self.scalarCount)
+    self.init(
+      columnVectors: simd_half4x4.columnVectors(
+        forLinearizedScalars: linearizedScalars
+      )
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Linear Combinations
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func linearCombination(
+    of first: simd_half4x4,
+    weight firstWeight: Scalar,
+    with other: simd_half4x4,
+    weight otherWeight: Scalar
+  ) -> simd_half4x4 {
+    return simd_linear_combination(
+      firstWeight,
+      first,
+      otherWeight,
+      other
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subscripting - Rows
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public subscript(rowIndex rowIndex: Int) -> RowVector {
+    get {
+      precondition(simd_half4x4.rowIndexRange.contains(rowIndex))
+      return RowVector(
+        columns.0[rowIndex],
+        columns.1[rowIndex],
+        columns.2[rowIndex],
+        columns.3[rowIndex]
+      )
+    }
+    set {
+      precondition(simd_half4x4.rowIndexRange.contains(rowIndex))
+      columns.0[rowIndex] = newValue[0]
+      columns.1[rowIndex] = newValue[1]
+      columns.2[rowIndex] = newValue[2]
+      columns.3[rowIndex] = newValue[3]
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Position & Linearization
+  // ------------------------------------------------------------------------ //
+
+  public static let matrixPositions: [MatrixPosition] = simd_half4x4.prepareMatrixPositionList()
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Bulk Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var rows: Rows {
+    get {
+      return (
+        RowVector(columns.0[0], columns.1[0], columns.2[0], columns.3[0]),
+        RowVector(columns.0[1], columns.1[1], columns.2[1], columns.3[1]),
+        RowVector(columns.0[2], columns.1[2], columns.2[2], columns.3[2]),
+        RowVector(columns.0[3], columns.1[3], columns.2[3], columns.3[3])
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Almost Equal Elements
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x4,
+    absoluteTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements(self, other, tolerance)
+  }
+
+  @inlinable
+  public func hasAlmostEqualElements(
+    to other: simd_half4x4,
+    relativeTolerance tolerance: Scalar
+  ) -> Bool {
+    return simd_almost_equal_elements_relative(self, other, tolerance)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return (
+        simd_length_squared(columns.0)
+        +
+        simd_length_squared(columns.1)
+        +
+        simd_length_squared(columns.2)
+        +
+        simd_length_squared(columns.3)
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_half4x4 {
+    return simd_mul((-1) as Scalar, self)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    self = simd_mul((-1) as Scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_half4x4) -> simd_half4x4 {
+    return simd_add(self, other)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_half4x4) {
+    self = simd_add(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_half4x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x4 {
+    return simd_add(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_half4x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_add(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction - Matrix
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_half4x4) -> simd_half4x4 {
+    return simd_sub(self, other)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_half4x4) {
+    self = simd_sub(self, other)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_half4x4,
+    multipliedBy scalar: Scalar
+  ) -> simd_half4x4 {
+    return simd_sub(self, simd_mul(scalar, other))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_half4x4,
+    multipliedBy scalar: Scalar
+  ) {
+    self = simd_sub(self, simd_mul(scalar, other))
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by scalar: Scalar) -> simd_half4x4 {
+    return simd_mul(scalar, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by scalar: Scalar) {
+    self = simd_mul(scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by scalar: Scalar) -> simd_half4x4 {
+    return simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  @inlinable
+  public mutating func formDivision(by scalar: Scalar) {
+    self = simd_mul((1 as Scalar) / scalar, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Vector Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onLeftBy columnVector: ColumnVector) -> RowVector {
+    return simd_mul(columnVector, self)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rowVector: RowVector) -> ColumnVector {
+    return simd_mul(self, rowVector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Matrix Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias CompatibleQuaternion = simd_quath
+  public typealias CompatibleMatrix2x4 = simd_half2x4
+  public typealias CompatibleMatrix4x2 = simd_half4x2
+  public typealias CompatibleMatrix3x4 = simd_half3x4
+  public typealias CompatibleMatrix4x3 = simd_half4x3
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization From Quaternion
+  // ------------------------------------------------------------------------ //
+
+  // `simd_matrix4x4(simd_quath)` returns a `simd_half4x4` (SIMD4 columns), so
+  // the bridge works correctly here.
+  @inlinable
+  public init(quaternion: CompatibleQuaternion) {
+    self = simd_matrix4x4(quaternion)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Determinants
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var determinant: Scalar {
+    get {
+      return simd_determinant(self)
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Inversion
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func inverted() -> simd_half4x4 {
+    return simd_inverse(self)
+  }
+
+  @inlinable
+  public mutating func formInverse() {
+    self = simd_inverse(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: simd_half4x4) -> simd_half4x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: simd_half4x4) -> simd_half4x4 {
+    return simd_mul(lhs, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy rhs: simd_half4x4) {
+    self = simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy lhs: simd_half4x4) {
+    self = simd_mul(lhs, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Square-Matrix Math - Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(onRightBy rhs: simd_half4x4) -> simd_half4x4 {
+    return simd_mul(self, simd_inverse(rhs))
+  }
+
+  @inlinable
+  public func divided(onLeftBy lhs: simd_half4x4) -> simd_half4x4 {
+    return simd_mul(simd_inverse(lhs), self)
+  }
+
+  @inlinable
+  public mutating func formDivision(onRightBy rhs: simd_half4x4) {
+    self = simd_mul(self, simd_inverse(rhs))
+  }
+
+  @inlinable
+  public mutating func formDivision(onLeftBy lhs: simd_half4x4) {
+    self = simd_mul(simd_inverse(lhs), self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Transposition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func transposed() -> simd_half4x4 {
+    return simd_transpose(self)
+  }
+
+  @inlinable
+  public mutating func formTranspose() {
+    self = simd_transpose(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Right Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix2x4) -> CompatibleMatrix2x4 {
+    return simd_mul(self, rhs)
+  }
+
+  @inlinable
+  public func multiplied(onRightBy rhs: CompatibleMatrix3x4) -> CompatibleMatrix3x4 {
+    return simd_mul(self, rhs)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Left Multiplication
+  // ------------------------------------------------------------------------ //
+
+  // `simd_mul(simd_half4x3, simd_half4x4) -> simd_half4x3`: the result is a
+  // half3-row shape; build it column-by-column.
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x3) -> CompatibleMatrix4x3 {
+    let l0 = lhs.columns.0
+    let l1 = lhs.columns.1
+    let l2 = lhs.columns.2
+    let l3 = lhs.columns.3
+    let s0 = columns.0
+    let s1 = columns.1
+    let s2 = columns.2
+    let s3 = columns.3
+    let rc0_a: SIMD3<Scalar> = l0 * s0[0] + l1 * s0[1]
+    let rc0_b: SIMD3<Scalar> = l2 * s0[2] + l3 * s0[3]
+    let rc1_a: SIMD3<Scalar> = l0 * s1[0] + l1 * s1[1]
+    let rc1_b: SIMD3<Scalar> = l2 * s1[2] + l3 * s1[3]
+    let rc2_a: SIMD3<Scalar> = l0 * s2[0] + l1 * s2[1]
+    let rc2_b: SIMD3<Scalar> = l2 * s2[2] + l3 * s2[3]
+    let rc3_a: SIMD3<Scalar> = l0 * s3[0] + l1 * s3[1]
+    let rc3_b: SIMD3<Scalar> = l2 * s3[2] + l3 * s3[3]
+    return CompatibleMatrix4x3(
+      columns: (
+        rc0_a + rc0_b,
+        rc1_a + rc1_b,
+        rc2_a + rc2_b,
+        rc3_a + rc3_b
+      )
+    )
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy lhs: CompatibleMatrix4x2) -> CompatibleMatrix4x2 {
+    return simd_mul(lhs, self)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x2Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x2Storage.swift
@@ -1,0 +1,117 @@
+//
+//  HalfMatrix2x2Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix2x2Storage :
+  Matrix2x2Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix2x2OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+
+  public typealias PassthroughValue = simd_half2x2
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix2x2Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x3Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x3Storage.swift
@@ -1,0 +1,120 @@
+//
+//  HalfMatrix2x3Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix2x3Storage :
+  Matrix2x3Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix2x3OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix2x2 = HalfMatrix2x2Storage
+  public typealias CompatibleMatrix3x3 = HalfMatrix3x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half2x3
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix2x3Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x4Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix2x4Storage.swift
@@ -1,0 +1,120 @@
+//
+//  HalfMatrix2x4Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix2x4Storage :
+  Matrix2x4Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix2x4OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix2x2 = HalfMatrix2x2Storage
+  public typealias CompatibleMatrix4x4 = HalfMatrix4x4Storage
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half2x4
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix2x4Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x2Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x2Storage.swift
@@ -1,0 +1,128 @@
+//
+//  HalfMatrix3x2Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix3x2Storage :
+  Matrix3x2Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix3x2OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix2x2 = HalfMatrix2x2Storage
+  public typealias CompatibleMatrix3x3 = HalfMatrix3x3Storage
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half3x2
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix3x2Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x3Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x3Storage.swift
@@ -1,0 +1,127 @@
+//
+//  HalfMatrix3x3Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix3x3Storage :
+  Matrix3x3Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix3x3OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleQuaternion = HalfQuaternionStorage
+
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half3x3
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix3x3Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x4Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix3x4Storage.swift
@@ -1,0 +1,128 @@
+//
+//  HalfMatrix3x4Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix3x4Storage :
+  Matrix3x4Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix3x4OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix4x4 = HalfMatrix4x4Storage
+  public typealias CompatibleMatrix3x3 = HalfMatrix3x3Storage
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half3x4
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix3x4Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x2Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x2Storage.swift
@@ -1,0 +1,136 @@
+//
+//  HalfMatrix4x2Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix4x2Storage :
+  Matrix4x2Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix4x2OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix4x4 = HalfMatrix4x4Storage
+  public typealias CompatibleMatrix2x2 = HalfMatrix2x2Storage
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half4x2
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix4x2Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+    columns.3.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+    case c3 = "c3"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        case .c3:
+          return 3
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      case 3:
+        self = .c3
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+    try container.encode(columns.3, forKey: .c3)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    let c3 = try container.decode(ColumnVector.self, forKey: .c3)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2, c3))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x3Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x3Storage.swift
@@ -1,0 +1,136 @@
+//
+//  HalfMatrix4x3Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix4x3Storage :
+  Matrix4x3Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix4x3OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix4x4 = HalfMatrix4x4Storage
+  public typealias CompatibleMatrix3x3 = HalfMatrix3x3Storage
+  public typealias CompatibleMatrix2x3 = HalfMatrix2x3Storage
+  public typealias CompatibleMatrix3x2 = HalfMatrix3x2Storage
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+
+  public typealias PassthroughValue = simd_half4x3
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix4x3Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+    columns.3.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+    case c3 = "c3"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        case .c3:
+          return 3
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      case 3:
+        self = .c3
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+    try container.encode(columns.3, forKey: .c3)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    let c3 = try container.decode(ColumnVector.self, forKey: .c3)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2, c3))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x4Storage.swift
+++ b/Sources/HDXLSIMDSupport/Matrices/Storages/Half/HalfMatrix4x4Storage.swift
@@ -1,0 +1,135 @@
+//
+//  HalfMatrix4x4Storage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfMatrix4x4Storage :
+  Matrix4x4Protocol,
+  MatrixOperatorSupportProtocol,
+  Matrix4x4OperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleQuaternion = HalfQuaternionStorage
+
+  public typealias CompatibleMatrix2x4 = HalfMatrix2x4Storage
+  public typealias CompatibleMatrix4x2 = HalfMatrix4x2Storage
+  public typealias CompatibleMatrix3x4 = HalfMatrix3x4Storage
+  public typealias CompatibleMatrix4x3 = HalfMatrix4x3Storage
+
+  public typealias PassthroughValue = simd_half4x4
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias RowVector = PassthroughValue.RowVector
+  public typealias ColumnVector = PassthroughValue.ColumnVector
+  public typealias DiagonalVector = PassthroughValue.DiagonalVector
+  public typealias Rows = PassthroughValue.Rows
+  public typealias Columns = PassthroughValue.Columns
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal static var typename: String {
+    get {
+      return "HalfMatrix4x4Storage"
+    }
+  }
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    columns.0.hash(into: &hasher)
+    columns.1.hash(into: &hasher)
+    columns.2.hash(into: &hasher)
+    columns.3.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "\(type(of: self).typename): \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "\(type(of: self).typename)(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  public enum CodingKeys: String, CodingKey {
+
+    case c0 = "c0"
+    case c1 = "c1"
+    case c2 = "c2"
+    case c3 = "c3"
+
+    @inlinable
+    public var intValue: Int? {
+      get {
+        switch self {
+        case .c0:
+          return 0
+        case .c1:
+          return 1
+        case .c2:
+          return 2
+        case .c3:
+          return 3
+        }
+      }
+    }
+
+    @inlinable
+    public init?(intValue: Int) {
+      switch intValue {
+      case 0:
+        self = .c0
+      case 1:
+        self = .c1
+      case 2:
+        self = .c2
+      case 3:
+        self = .c3
+      default:
+        return nil
+      }
+    }
+
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(columns.0, forKey: .c0)
+    try container.encode(columns.1, forKey: .c1)
+    try container.encode(columns.2, forKey: .c2)
+    try container.encode(columns.3, forKey: .c3)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let c0 = try container.decode(ColumnVector.self, forKey: .c0)
+    let c1 = try container.decode(ColumnVector.self, forKey: .c1)
+    let c2 = try container.decode(ColumnVector.self, forKey: .c2)
+    let c3 = try container.decode(ColumnVector.self, forKey: .c3)
+    self.init(
+      passthroughValue: PassthroughValue(columns: (c0, c1, c2, c3))
+    )
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x2+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x2+NumericAggregate.swift
@@ -1,0 +1,23 @@
+//
+//  simd_half2x2+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half2x2 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x3+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x3+NumericAggregate.swift
@@ -1,0 +1,23 @@
+//
+//  simd_half2x3+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half2x3 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x4+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half2x4+NumericAggregate.swift
@@ -1,0 +1,23 @@
+//
+//  simd_half2x4+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half2x4 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x2+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x2+NumericAggregate.swift
@@ -1,0 +1,24 @@
+//
+//  simd_half3x2+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half3x2 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x3+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x3+NumericAggregate.swift
@@ -1,0 +1,24 @@
+//
+//  simd_half3x3+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half3x3 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x4+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half3x4+NumericAggregate.swift
@@ -1,0 +1,24 @@
+//
+//  simd_half3x4+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half3x4 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x2+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x2+NumericAggregate.swift
@@ -1,0 +1,25 @@
+//
+//  simd_half4x2+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half4x2 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate),
+      columns.3.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x3+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x3+NumericAggregate.swift
@@ -1,0 +1,25 @@
+//
+//  simd_half4x3+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half4x3 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate),
+      columns.3.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x4+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Matrices/Half/simd_half4x4+NumericAggregate.swift
@@ -1,0 +1,25 @@
+//
+//  simd_half4x4+NumericAggregate.swift
+//
+
+import Foundation
+import simd
+
+extension simd_half4x4 : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      columns.0.allNumericEntriesSatisfy(predicate),
+      columns.1.allNumericEntriesSatisfy(predicate),
+      columns.2.allNumericEntriesSatisfy(predicate),
+      columns.3.allNumericEntriesSatisfy(predicate)
+    else {
+      return false
+    }
+    return true
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Quaternion+NumericAggregate.swift
+++ b/Sources/HDXLSIMDSupport/NumericAggregate/Conformances/Quaternion+NumericAggregate.swift
@@ -31,9 +31,9 @@ extension simd_quatf : NumericAggregate {
 // -------------------------------------------------------------------------- //
 
 extension simd_quatd : NumericAggregate {
-  
+
   public typealias NumericEntryRepresentation = Double
-  
+
   @inlinable
   public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
     guard
@@ -44,5 +44,28 @@ extension simd_quatd : NumericAggregate {
     }
     return true
   }
-  
+
+}
+
+// -------------------------------------------------------------------------- //
+// MARK: simd_quath - NumericAggregate
+// -------------------------------------------------------------------------- //
+
+extension simd_quath : NumericAggregate {
+
+  public typealias NumericEntryRepresentation = Float16
+
+  // `simd_quath` does not (yet) bridge the `.real`/`.imag` accessors that
+  // `simd_quatf`/`simd_quatd` have, so we route through the free C functions.
+  @inlinable
+  public func allNumericEntriesSatisfy(_ predicate: (NumericEntryRepresentation) -> Bool) -> Bool {
+    guard
+      predicate(simd_real(self)),
+      simd_imag(self).allNumericEntriesSatisfy(predicate)
+    else {
+        return false
+    }
+    return true
+  }
+
 }

--- a/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quath+Equatable.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quath+Equatable.swift
@@ -1,0 +1,21 @@
+//
+//  simd_quath+Equatable.swift
+//
+
+import Foundation
+import simd
+
+// `simd_quatf` and `simd_quatd` are `Equatable` via the Swift overlay; the
+// half-precision variant is not yet bridged that way as of macOS 26. The
+// `Passthrough+Equatable` default in this package relies on
+// `PassthroughValue: Equatable`, so we add the explicit conformance here so
+// `HalfQuaternionStorage` can pick up the same `==` mechanism as
+// `FloatQuaternionStorage`/`DoubleQuaternionStorage`. If/when the Swift
+// overlay bridges this itself, this can be removed.
+
+extension simd_quath : @retroactive Equatable {
+  @inlinable
+  public static func == (lhs: simd_quath, rhs: simd_quath) -> Bool {
+    return lhs.vector == rhs.vector
+  }
+}

--- a/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quath+QuaternionProtocol.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/NativeConformances/simd_quath+QuaternionProtocol.swift
@@ -1,0 +1,427 @@
+//
+//  simd_quath+QuaternionProtocol.swift
+//
+
+import Foundation
+import simd
+
+// As of macOS 26 the standard simd module provides `simd_quath` and the full
+// suite of C-level operations (`simd_quaternion`, `simd_real`, `simd_imag`,
+// `simd_normalize`, `simd_inverse`, `simd_conjugate`, `simd_dot`, `simd_mul`,
+// `simd_act`, `simd_slerp`, `simd_slerp_longest`, `simd_bezier`,
+// `simd_spline`), but does not yet bridge the Swift-side conveniences (the
+// `init(ix:iy:iz:r:)`/`init(real:imag:)`/`init(angle:axis:)` initializers,
+// the `.real`/`.imag`/`.angle`/`.axis`/`.length`/`.normalized`/`.inverse`/
+// `.conjugate` accessors, or any operators) that exist for `simd_quatf` and
+// `simd_quatd`. This conformance fills in those Swift-side conveniences by
+// calling the C entry points directly.
+
+extension simd_quath : QuaternionProtocol {
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Compatible Types
+  // ------------------------------------------------------------------------ //
+
+  public typealias Scalar = Float16
+  public typealias CompatibleMatrix3x3 = simd_half3x3
+  public typealias CompatibleMatrix4x4 = simd_half4x4
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Initialization
+  // ------------------------------------------------------------------------ //
+
+  // already exists:
+  // init()
+
+  @inlinable
+  public init(i: Scalar, j: Scalar, k: Scalar, real: Scalar) {
+    self = simd_quaternion(i, j, k, real)
+  }
+
+  @inlinable
+  public init(x: Scalar, y: Scalar, z: Scalar, real: Scalar) {
+    self = simd_quaternion(x, y, z, real)
+  }
+
+  @inlinable
+  public init(
+    realComponent: Scalar,
+    imaginaryComponent: Vector3
+  ) {
+    self = simd_quaternion(
+      SIMD4<Scalar>(
+        imaginaryComponent.x,
+        imaginaryComponent.y,
+        imaginaryComponent.z,
+        realComponent
+      )
+    )
+  }
+
+  @inlinable
+  public init(
+    angleInRadians angle: Scalar,
+    rotationAxis axis: Vector3
+  ) {
+    self = simd_quaternion(angle, axis)
+  }
+
+  @inlinable
+  public init(
+    rotating origin: Vector3,
+    onto destination: Vector3
+  ) {
+    self = simd_quaternion(origin, destination)
+  }
+
+  @inlinable
+  public init(rotationMatrix matrix: CompatibleMatrix3x3) {
+    self = simd_quaternion(matrix)
+  }
+
+  @inlinable
+  public init(rotationMatrix matrix: CompatibleMatrix4x4) {
+    self = simd_quaternion(matrix)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Other Constructors
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public static func slerp(
+    _ q0: simd_quath,
+    _ q1: simd_quath,
+    _ t: Scalar,
+    strategy: QuaternionSlerpStrategy
+  ) -> simd_quath {
+    switch strategy {
+    case .automatic:
+      return simd_quath.slerpShortest(q0, q1, t)
+    case .shortest:
+      return simd_quath.slerpShortest(q0, q1, t)
+    case .longest:
+      return simd_quath.slerpLongest(q0, q1, t)
+    }
+  }
+
+  @inlinable
+  public static func slerpShortest(
+    _ q0: simd_quath,
+    _ q1: simd_quath,
+    _ t: Scalar
+  ) -> simd_quath {
+    return simd_slerp(q0, q1, t)
+  }
+
+  @inlinable
+  public static func slerpLongest(
+    _ q0: simd_quath,
+    _ q1: simd_quath,
+    _ t: Scalar
+  ) -> simd_quath {
+    return simd_slerp_longest(q0, q1, t)
+  }
+
+  @inlinable
+  public static func bezier(
+    q0: simd_quath,
+    q1: simd_quath,
+    q2: simd_quath,
+    q3: simd_quath,
+    t: Scalar
+  ) -> simd_quath {
+    return simd_bezier(q0, q1, q2, q3, t)
+  }
+
+  @inlinable
+  public static func spline(
+    q0: simd_quath,
+    q1: simd_quath,
+    q2: simd_quath,
+    q3: simd_quath,
+    t: Scalar
+  ) -> simd_quath {
+    return simd_spline(q0, q1, q2, q3, t)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Basic Properties
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var realComponent: Scalar {
+    get {
+      return simd_real(self)
+    }
+    set {
+      vector.w = newValue
+    }
+    _modify {
+      yield &vector.w
+    }
+  }
+
+  @inlinable
+  public var imaginaryComponent: Vector3 {
+    get {
+      return simd_imag(self)
+    }
+    set {
+      vector.x = newValue.x
+      vector.y = newValue.y
+      vector.z = newValue.z
+    }
+  }
+
+  @inlinable
+  public var angleInRadians: Scalar {
+    get {
+      return simd_angle(self)
+    }
+  }
+
+  @inlinable
+  public var rotationAxis: Vector3 {
+    get {
+      return simd_axis(self)
+    }
+  }
+
+  @inlinable
+  public var length: Scalar {
+    get {
+      return simd_length(self)
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Applying to Vectors
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func apply(to vector: Vector3) -> Vector3 {
+    return simd_act(self, vector)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Normalization
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func normalized() -> simd_quath {
+    return simd_normalize(self)
+  }
+
+  @inlinable
+  public mutating func formNormalization() {
+    self = simd_normalize(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Norms
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public var componentwiseMagnitudeSquared: Scalar {
+    get {
+      return simd_length_squared(vector)
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Inversion
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func inverted() -> simd_quath {
+    return simd_inverse(self)
+  }
+
+  @inlinable
+  public mutating func formInverse() {
+    self = simd_inverse(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Conjugation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func conjugated() -> simd_quath {
+    return simd_conjugate(self)
+  }
+
+  @inlinable
+  public mutating func formConjugate() {
+    self = simd_conjugate(self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Negation
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func negated() -> simd_quath {
+    return simd_quath(vector: -vector)
+  }
+
+  @inlinable
+  public mutating func formNegation() {
+    vector = -vector
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Addition
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(_ other: simd_quath) -> simd_quath {
+    return simd_quath(vector: vector + other.vector)
+  }
+
+  @inlinable
+  public mutating func formAddition(of other: simd_quath) {
+    vector += other.vector
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMA
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func adding(
+    _ other: simd_quath,
+    multipliedBy factor: Scalar
+  ) -> simd_quath {
+    return simd_quath(vector: vector + (other.vector * factor))
+  }
+
+  @inlinable
+  public mutating func formAddition(
+    of other: simd_quath,
+    multipliedBy factor: Scalar
+  ) {
+    vector += (other.vector * factor)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Subtraction
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(_ other: simd_quath) -> simd_quath {
+    return simd_quath(vector: vector - other.vector)
+  }
+
+  @inlinable
+  public mutating func formSubtraction(of other: simd_quath) {
+    vector -= other.vector
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: FMS
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func subtracting(
+    _ other: simd_quath,
+    multipliedBy factor: Scalar
+  ) -> simd_quath {
+    return simd_quath(vector: vector - (other.vector * factor))
+  }
+
+  @inlinable
+  public mutating func formSubtraction(
+    of other: simd_quath,
+    multipliedBy factor: Scalar
+  ) {
+    vector -= (other.vector * factor)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(by factor: Scalar) -> simd_quath {
+    return simd_mul(self, factor)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(by factor: Scalar) {
+    self = simd_mul(self, factor)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Scalar Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(by factor: Scalar) -> simd_quath {
+    return simd_quath(vector: vector / factor)
+  }
+
+  @inlinable
+  public mutating func formDivision(by factor: Scalar) {
+    vector /= factor
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Quaternion Multiplication
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func multiplied(onRightBy other: simd_quath) -> simd_quath {
+    return simd_mul(self, other)
+  }
+
+  @inlinable
+  public func multiplied(onLeftBy other: simd_quath) -> simd_quath {
+    return simd_mul(other, self)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onRightBy other: simd_quath) {
+    self = simd_mul(self, other)
+  }
+
+  @inlinable
+  public mutating func formMultiplication(onLeftBy other: simd_quath) {
+    self = simd_mul(other, self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Quaternion Division
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func divided(onRightBy other: simd_quath) -> simd_quath {
+    return simd_mul(self, simd_inverse(other))
+  }
+
+  @inlinable
+  public func divided(onLeftBy other: simd_quath) -> simd_quath {
+    return simd_mul(simd_inverse(other), self)
+  }
+
+  @inlinable
+  public mutating func formDivision(onRightBy other: simd_quath) {
+    self = simd_mul(self, simd_inverse(other))
+  }
+
+  @inlinable
+  public mutating func formDivision(onLeftBy other: simd_quath) {
+    self = simd_mul(simd_inverse(other), self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Quaternion Dot Product
+  // ------------------------------------------------------------------------ //
+
+  @inlinable
+  public func dotted(with other: simd_quath) -> Scalar {
+    return simd_dot(self, other)
+  }
+
+}

--- a/Sources/HDXLSIMDSupport/Quaternion/Storages/HalfQuaternionStorage.swift
+++ b/Sources/HDXLSIMDSupport/Quaternion/Storages/HalfQuaternionStorage.swift
@@ -1,0 +1,71 @@
+//
+//  HalfQuaternionStorage.swift
+//
+
+import Foundation
+import simd
+
+@frozen
+public struct HalfQuaternionStorage :
+  QuaternionProtocol,
+  QuaternionOperatorSupportProtocol,
+  Passthrough,
+  NumericAggregate,
+  Hashable,
+  CustomStringConvertible,
+  CustomDebugStringConvertible,
+  Codable
+{
+
+  public typealias CompatibleMatrix3x3 = HalfMatrix3x3Storage
+  public typealias CompatibleMatrix4x4 = HalfMatrix4x4Storage
+
+  public typealias PassthroughValue = simd_quath
+  public typealias Scalar = PassthroughValue.Scalar
+  public typealias NumericEntryRepresentation = PassthroughValue.NumericEntryRepresentation
+
+  @usableFromInline
+  internal typealias QVector = SIMD4<Scalar>
+
+  public var passthroughValue: PassthroughValue
+
+  @inlinable
+  public init(passthroughValue: PassthroughValue) {
+    self.passthroughValue = passthroughValue
+  }
+
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    passthroughValue.vector.hash(into: &hasher)
+  }
+
+  @inlinable
+  public var description: String {
+    get {
+      return "HalfQuaternionStorage: \(String(describing: passthroughValue))"
+    }
+  }
+
+  @inlinable
+  public var debugDescription: String {
+    get {
+      return "HalfQuaternionStorage(passthroughValue: \(String(reflecting: passthroughValue)))"
+    }
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(passthroughValue.vector)
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let vector = try container.decode(QVector.self)
+    self.init(
+      passthroughValue: PassthroughValue(vector: vector)
+    )
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/DoubleMatrices.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/DoubleMatrices.swift
@@ -1,239 +1,241 @@
 import Foundation
 import simd
 
+// Each native `simd_double*x*` matrix is column-major: its `columns` tuple is
+// a tuple of `SIMD<M, Double>` vectors. We compute distances by issuing one
+// SIMD subtract per column, taking the componentwise absolute value, and then
+// horizontally reducing (sum for L1, max for L∞) across the resulting vectors.
+//
+// These hand-written implementations are cross-checked against the generic
+// reference (`_l1Distance` / `_lInfinityDistance`) in the sanity tests.
+
+// MARK: 2-column shapes
+
 extension simd_double2x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Double
   typealias LInfinityDistance = Double
-  
-  
-  func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
-    )
-  }
-  
-}
 
-extension simd_double3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
   func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
-  
-  func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-  
-}
 
-extension simd_double4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-  
   func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
 }
 
 extension simd_double2x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
-    )
-  }
-  
-}
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
 
-extension simd_double3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
   func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
-  
-  func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-  
-}
 
-extension simd_double4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-  
   func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
 }
 
 extension simd_double2x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
   func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
+}
+
+// MARK: 3-column shapes
+
+extension simd_double3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
+  func l1Distance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_double3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
+  func l1Distance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_double3x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
   func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
     )
   }
-  
+}
+
+// MARK: 4-column shapes
+
+extension simd_double4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
+  func l1Distance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_double4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
+  func l1Distance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Double {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_double4x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
+  typealias L1Distance = Double
+  typealias LInfinityDistance = Double
+
   func l1Distance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Double {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
     )
   }
-  
 }

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/FloatMatrices.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/FloatMatrices.swift
@@ -1,239 +1,236 @@
 import Foundation
 import simd
 
+// SIMD-friendly hand-written L1 / L∞ distance implementations for the native
+// single-precision matrix types. See `DoubleMatrices.swift` for the rationale.
+
+// MARK: 2-column shapes
+
 extension simd_float2x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Float
   typealias LInfinityDistance = Float
-  
 
   func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
-}
-
-extension simd_float3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-
-}
-
-extension simd_float4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-
-  func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
-    )
-  }
-  
 }
 
 extension simd_float2x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
-    )
-  }
-  
-}
-
-extension simd_float3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-  
-  func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-  
-}
-
-extension simd_float4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
 
   func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
 }
 
 extension simd_float2x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
 
   func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-  
+}
+
+// MARK: 3-column shapes
+
+extension simd_float3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
+
+  func l1Distance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_float3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
+
+  func l1Distance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_float3x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
 
   func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
     )
   }
-  
+
   func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
     )
   }
-  
+}
+
+// MARK: 4-column shapes
+
+extension simd_float4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
+
+  func l1Distance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_float4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
+
+  func l1Distance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_float4x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float
+  typealias LInfinityDistance = Float
 
   func l1Distance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-  
-  func lInfinityDistance(to other: Self) -> Float {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
     )
   }
 
+  func lInfinityDistance(to other: Self) -> Float {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
 }

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/HalfMatrices.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/HalfMatrices.swift
@@ -1,0 +1,238 @@
+import Foundation
+import simd
+
+extension simd_half2x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1])
+    )
+  }
+
+}
+
+extension simd_half3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2])
+    )
+  }
+
+}
+
+extension simd_half4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+      +
+      these[3].l1Distance(to: those[3])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2]),
+      these[3].lInfinityDistance(to: those[3])
+    )
+  }
+
+}
+
+extension simd_half2x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1])
+    )
+  }
+
+}
+
+extension simd_half3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2])
+    )
+  }
+
+}
+
+extension simd_half4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+      +
+      these[3].l1Distance(to: those[3])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2]),
+      these[3].lInfinityDistance(to: those[3])
+    )
+  }
+
+}
+
+extension simd_half2x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1])
+    )
+  }
+
+}
+
+extension simd_half3x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2])
+    )
+  }
+
+}
+
+extension simd_half4x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+
+  func l1Distance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return (
+      these[0].l1Distance(to: those[0])
+      +
+      these[1].l1Distance(to: those[1])
+      +
+      these[2].l1Distance(to: those[2])
+      +
+      these[3].l1Distance(to: those[3])
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let these = self.rowVectors
+    let those = other.rowVectors
+    return max(
+      these[0].lInfinityDistance(to: those[0]),
+      these[1].lInfinityDistance(to: those[1]),
+      these[2].lInfinityDistance(to: those[2]),
+      these[3].lInfinityDistance(to: those[3])
+    )
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/HalfMatrices.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/HalfMatrices.swift
@@ -1,238 +1,236 @@
 import Foundation
 import simd
 
+// SIMD-friendly hand-written L1 / L∞ distance implementations for the native
+// half-precision matrix types. See `DoubleMatrices.swift` for the rationale.
+
+// MARK: 2-column shapes
+
 extension simd_half2x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Float16
   typealias LInfinityDistance = Float16
 
   func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-
-}
-
-extension simd_half3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-
-  func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-    )
-  }
-
-  func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-
-}
-
-extension simd_half4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-
-  func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-
-  func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
-    )
-  }
-
 }
 
 extension simd_half2x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
 
   func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
     )
   }
-
-}
-
-extension simd_half3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-
-  func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-    )
-  }
-
-  func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
-    )
-  }
-
-}
-
-extension simd_half4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
-
-  func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
-    )
-  }
-
-  func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
-    return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
-    )
-  }
-
 }
 
 extension simd_half2x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
 
   func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max()
+    )
+  }
+}
+
+// MARK: 3-column shapes
+
+extension simd_half3x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  func l1Distance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
     )
   }
 
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_half3x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  func l1Distance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_half3x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
 
   func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max()
+    )
+  }
+}
+
+// MARK: 4-column shapes
+
+extension simd_half4x2: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  func l1Distance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
     )
   }
 
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
+}
+
+extension simd_half4x3: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  func l1Distance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return (
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
+    )
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    let lhs = self.columns
+    let rhs = other.columns
+    return max(
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
+    )
+  }
 }
 
 extension simd_half4x4: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
 
   func l1Distance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return (
-      these[0].l1Distance(to: those[0])
-      +
-      these[1].l1Distance(to: those[1])
-      +
-      these[2].l1Distance(to: those[2])
-      +
-      these[3].l1Distance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().sum()
+      + (lhs.1 - rhs.1).absoluteValue().sum()
+      + (lhs.2 - rhs.2).absoluteValue().sum()
+      + (lhs.3 - rhs.3).absoluteValue().sum()
     )
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    let these = self.rowVectors
-    let those = other.rowVectors
+    let lhs = self.columns
+    let rhs = other.columns
     return max(
-      these[0].lInfinityDistance(to: those[0]),
-      these[1].lInfinityDistance(to: those[1]),
-      these[2].lInfinityDistance(to: those[2]),
-      these[3].lInfinityDistance(to: those[3])
+      (lhs.0 - rhs.0).absoluteValue().max(),
+      (lhs.1 - rhs.1).absoluteValue().max(),
+      (lhs.2 - rhs.2).absoluteValue().max(),
+      (lhs.3 - rhs.3).absoluteValue().max()
     )
   }
-
 }

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Matrices.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Matrices.swift
@@ -1,11 +1,22 @@
 import Foundation
 @testable import HDXLSIMDSupport
 
+// -------------------------------------------------------------------------- //
+// MARK: Generic Reference Implementations
+// -------------------------------------------------------------------------- //
+//
+// `_l1Distance` / `_lInfinityDistance` iterate over `Self.matrixPositions`
+// using the scalar position subscript. They are correct for every shape, but
+// touch one scalar at a time and so defeat SIMD vectorization. Concrete types
+// are expected to override the canonical `l1Distance` / `lInfinityDistance`
+// methods with SIMD-friendly variants; the underscored helpers stay reachable
+// so tests can cross-check the two implementations against each other.
+
 extension MatrixProtocol where
   Self: L1DistanceMeasureable,
   Scalar == L1Distance
 {
-  func l1Distance(to other: Self) -> L1Distance {
+  func _l1Distance(to other: Self) -> L1Distance {
     var distance: L1Distance = 0
     for position in Self.matrixPositions {
       distance += abs(
@@ -20,15 +31,47 @@ extension MatrixProtocol where
   Self: LInfinityDistanceMeasureable,
   Scalar == LInfinityDistance
 {
-  func lInfinityDistance(to other: Self) -> LInfinityDistance {
+  func _lInfinityDistance(to other: Self) -> LInfinityDistance {
     return Self.matrixPositions.lazy.map { position in
       abs(
         self[position: position] - other[position: position]
       )
     }.max() ?? 0
   }
-  
 }
+
+// -------------------------------------------------------------------------- //
+// MARK: Default Delegations
+// -------------------------------------------------------------------------- //
+//
+// Types that do not provide their own `l1Distance` / `lInfinityDistance`
+// inherit these, which forward to the generic reference.
+
+extension MatrixProtocol where
+  Self: L1DistanceMeasureable,
+  Scalar == L1Distance
+{
+  func l1Distance(to other: Self) -> L1Distance {
+    return _l1Distance(to: other)
+  }
+}
+
+extension MatrixProtocol where
+  Self: LInfinityDistanceMeasureable,
+  Scalar == LInfinityDistance
+{
+  func lInfinityDistance(to other: Self) -> LInfinityDistance {
+    return _lInfinityDistance(to: other)
+  }
+}
+
+// -------------------------------------------------------------------------- //
+// MARK: Wrapper Conformances
+// -------------------------------------------------------------------------- //
+//
+// `Matrix*x*<Scalar>` types adopt the generic reference by default. The
+// per-shape SIMD-friendly implementations live on the underlying native
+// `simd_*` types in `Double/Float/HalfMatrices.swift`.
 
 extension Matrix2x2: L1DistanceMeasureable, LInfinityDistanceMeasureable { }
 extension Matrix2x3: L1DistanceMeasureable, LInfinityDistanceMeasureable { }

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Quaternions.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Quaternions.swift
@@ -2,49 +2,97 @@ import Foundation
 import simd
 @testable import HDXLSIMDSupport
 
+// -------------------------------------------------------------------------- //
+// MARK: Generic Reference Implementations
+// -------------------------------------------------------------------------- //
+//
+// `_l1Distance` / `_lInfinityDistance` access the four quaternion components
+// individually. They're correct for any conforming type but don't take
+// advantage of SIMD reductions on the underlying 4-vector. Concrete types are
+// expected to override the canonical methods with SIMD-friendly variants; the
+// underscored helpers stay reachable so tests can cross-check the two.
+
 extension QuaternionProtocol where
-Self: L1DistanceMeasureable,
-Scalar == L1Distance
+  Self: L1DistanceMeasureable,
+  Scalar == L1Distance
 {
-  func l1Distance(to other: Self) -> L1Distance {
+  func _l1Distance(to other: Self) -> L1Distance {
     return (
       abs(realComponent - other.realComponent)
-      +
-      imaginaryComponent.l1Distance(to: other.imaginaryComponent)
+      + abs(imaginaryComponent.x - other.imaginaryComponent.x)
+      + abs(imaginaryComponent.y - other.imaginaryComponent.y)
+      + abs(imaginaryComponent.z - other.imaginaryComponent.z)
     )
   }
 }
 
 extension QuaternionProtocol where
-Self: LInfinityDistanceMeasureable,
-Scalar == LInfinityDistance
+  Self: LInfinityDistanceMeasureable,
+  Scalar == LInfinityDistance
 {
-  func lInfinityDistance(to other: Self) -> LInfinityDistance {
-    return max(
-      abs(realComponent - other.realComponent),
-      imaginaryComponent.l1Distance(to: other.imaginaryComponent)
-    )
+  func _lInfinityDistance(to other: Self) -> LInfinityDistance {
+    let r = abs(realComponent - other.realComponent)
+    let x = abs(imaginaryComponent.x - other.imaginaryComponent.x)
+    let y = abs(imaginaryComponent.y - other.imaginaryComponent.y)
+    let z = abs(imaginaryComponent.z - other.imaginaryComponent.z)
+    return max(r, x, y, z)
   }
 }
+
+// -------------------------------------------------------------------------- //
+// MARK: Default Delegations
+// -------------------------------------------------------------------------- //
+
+extension QuaternionProtocol where
+  Self: L1DistanceMeasureable,
+  Scalar == L1Distance
+{
+  func l1Distance(to other: Self) -> L1Distance {
+    return _l1Distance(to: other)
+  }
+}
+
+extension QuaternionProtocol where
+  Self: LInfinityDistanceMeasureable,
+  Scalar == LInfinityDistance
+{
+  func lInfinityDistance(to other: Self) -> LInfinityDistance {
+    return _lInfinityDistance(to: other)
+  }
+}
+
+// -------------------------------------------------------------------------- //
+// MARK: Wrapper Conformance
+// -------------------------------------------------------------------------- //
+//
+// `Quaternion<Scalar>` uses the generic reference by default. The
+// SIMD-friendly per-representation implementations live on the underlying
+// `simd_quat*` types below.
 
 extension Quaternion: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Scalar
   typealias LInfinityDistance = Scalar
 }
 
+// -------------------------------------------------------------------------- //
+// MARK: simd_quat* SIMD-Friendly Hand-Written
+// -------------------------------------------------------------------------- //
+//
+// Each native quaternion stores its components in a `vector: SIMD4`, with the
+// real part in the `w` lane. A single SIMD subtraction + componentwise
+// absolute value, followed by a SIMD horizontal reduction, computes either
+// distance in one pass.
+
 extension simd_quatf: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Float
   typealias LInfinityDistance = Float
-  
+
   func l1Distance(to other: Self) -> Float {
-    return abs(real - other.real) + imag.l1Distance(to: other.imag)
+    return (vector - other.vector).absoluteValue().sum()
   }
-  
+
   func lInfinityDistance(to other: Self) -> Float {
-    return max(
-      abs(real - other.real),
-      imag.lInfinityDistance(to: other.imag)
-    )
+    return (vector - other.vector).absoluteValue().max()
   }
 }
 
@@ -53,14 +101,11 @@ extension simd_quatd: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias LInfinityDistance = Double
 
   func l1Distance(to other: Self) -> Double {
-    return abs(real - other.real) + imag.l1Distance(to: other.imag)
+    return (vector - other.vector).absoluteValue().sum()
   }
 
   func lInfinityDistance(to other: Self) -> Double {
-    return max(
-      abs(real - other.real),
-      imag.lInfinityDistance(to: other.imag)
-    )
+    return (vector - other.vector).absoluteValue().max()
   }
 }
 
@@ -68,17 +113,11 @@ extension simd_quath: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Float16
   typealias LInfinityDistance = Float16
 
-  // `simd_quath` doesn't yet bridge `.real`/`.imag` accessors; route through
-  // the free C functions.
   func l1Distance(to other: Self) -> Float16 {
-    return abs(simd_real(self) - simd_real(other))
-      + simd_imag(self).l1Distance(to: simd_imag(other))
+    return (vector - other.vector).absoluteValue().sum()
   }
 
   func lInfinityDistance(to other: Self) -> Float16 {
-    return max(
-      abs(simd_real(self) - simd_real(other)),
-      simd_imag(self).lInfinityDistance(to: simd_imag(other))
-    )
+    return (vector - other.vector).absoluteValue().max()
   }
 }

--- a/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Quaternions.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/DistanceMeasureable/Conformances/Quaternions.swift
@@ -51,15 +51,34 @@ extension simd_quatf: L1DistanceMeasureable, LInfinityDistanceMeasureable {
 extension simd_quatd: L1DistanceMeasureable, LInfinityDistanceMeasureable {
   typealias L1Distance = Double
   typealias LInfinityDistance = Double
-  
+
   func l1Distance(to other: Self) -> Double {
     return abs(real - other.real) + imag.l1Distance(to: other.imag)
   }
-  
+
   func lInfinityDistance(to other: Self) -> Double {
     return max(
       abs(real - other.real),
       imag.lInfinityDistance(to: other.imag)
+    )
+  }
+}
+
+extension simd_quath: L1DistanceMeasureable, LInfinityDistanceMeasureable {
+  typealias L1Distance = Float16
+  typealias LInfinityDistance = Float16
+
+  // `simd_quath` doesn't yet bridge `.real`/`.imag` accessors; route through
+  // the free C functions.
+  func l1Distance(to other: Self) -> Float16 {
+    return abs(simd_real(self) - simd_real(other))
+      + simd_imag(self).l1Distance(to: simd_imag(other))
+  }
+
+  func lInfinityDistance(to other: Self) -> Float16 {
+    return max(
+      abs(simd_real(self) - simd_real(other)),
+      simd_imag(self).lInfinityDistance(to: simd_imag(other))
     )
   }
 }

--- a/Tests/HDXLSIMDSupportTests/Support/IntegerTupleConstructible/HalfMatrices+IntegerTupleConstructible.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/IntegerTupleConstructible/HalfMatrices+IntegerTupleConstructible.swift
@@ -1,0 +1,128 @@
+import Foundation
+import simd
+
+extension simd_half2x2 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous8<Int>
+
+  init(integerTuple i: Homogeneous8<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1)),
+        RowVector(integerTuple: (i.2,  i.3))
+      ]
+    )
+  }
+}
+
+extension simd_half3x2 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous12<Int>
+
+  init(integerTuple i: Homogeneous12<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2)),
+        RowVector(integerTuple: (i.3,  i.4,  i.5))
+      ]
+    )
+  }
+}
+
+extension simd_half4x2 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous16<Int>
+
+  init(integerTuple i: Homogeneous16<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2,  i.3)),
+        RowVector(integerTuple: (i.4,  i.5,  i.6,  i.7))
+      ]
+    )
+  }
+}
+
+extension simd_half2x3 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous8<Int>
+
+  init(integerTuple i: Homogeneous8<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1)),
+        RowVector(integerTuple: (i.2,  i.3)),
+        RowVector(integerTuple: (i.4,  i.5))
+      ]
+    )
+  }
+}
+
+extension simd_half3x3 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous12<Int>
+
+  init(integerTuple i: Homogeneous12<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2)),
+        RowVector(integerTuple: (i.3,  i.4,  i.5)),
+        RowVector(integerTuple: (i.6,  i.7,  i.8))
+      ]
+    )
+  }
+}
+
+extension simd_half4x3 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous16<Int>
+
+  init(integerTuple i: Homogeneous16<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2,  i.3)),
+        RowVector(integerTuple: (i.4,  i.5,  i.6,  i.7)),
+        RowVector(integerTuple: (i.8,  i.9,  i.10, i.11))
+      ]
+    )
+  }
+}
+
+extension simd_half2x4 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous8<Int>
+
+  init(integerTuple i: Homogeneous8<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1)),
+        RowVector(integerTuple: (i.2,  i.3)),
+        RowVector(integerTuple: (i.4,  i.5)),
+        RowVector(integerTuple: (i.6, i.7))
+      ]
+    )
+  }
+}
+
+extension simd_half3x4 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous12<Int>
+
+  init(integerTuple i: Homogeneous12<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2)),
+        RowVector(integerTuple: (i.3,  i.4,  i.5)),
+        RowVector(integerTuple: (i.6,  i.7,  i.8)),
+        RowVector(integerTuple: (i.9, i.10, i.11))
+      ]
+    )
+  }
+}
+
+extension simd_half4x4 : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous16<Int>
+
+  init(integerTuple i: Homogeneous16<Int>) {
+    self.init(
+      rowVectors: [
+        RowVector(integerTuple: (i.0,  i.1,  i.2,  i.3)),
+        RowVector(integerTuple: (i.4,  i.5,  i.6,  i.7)),
+        RowVector(integerTuple: (i.8,  i.9,  i.10, i.11)),
+        RowVector(integerTuple: (i.12, i.13, i.14, i.15))
+      ]
+    )
+  }
+}

--- a/Tests/HDXLSIMDSupportTests/Support/IntegerTupleConstructible/Quaternions+IntegerTupleConstructible.swift
+++ b/Tests/HDXLSIMDSupportTests/Support/IntegerTupleConstructible/Quaternions+IntegerTupleConstructible.swift
@@ -17,13 +17,26 @@ extension simd_quatf : IntegerTupleConstructible {
 
 extension simd_quatd : IntegerTupleConstructible {
   typealias IntegerTuple = Homogeneous4<Int>
-  
+
   init(integerTuple t: Homogeneous4<Int>) {
     self.init(
       i: Double(t.0),
       j: Double(t.1),
       k: Double(t.2),
       real: Double(t.3)
+    )
+  }
+}
+
+extension simd_quath : IntegerTupleConstructible {
+  typealias IntegerTuple = Homogeneous4<Int>
+
+  init(integerTuple t: Homogeneous4<Int>) {
+    self.init(
+      i: Float16(t.0),
+      j: Float16(t.1),
+      k: Float16(t.2),
+      real: Float16(t.3)
     )
   }
 }

--- a/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/HalfMatrixShapeSanityTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/HalfMatrixShapeSanityTests.swift
@@ -1,0 +1,81 @@
+//
+//  HalfMatrixShapeSanityTests.swift
+//
+
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+class HalfMatrixShapeSanityTests: XCTestCase {
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Shape Support
+  // ------------------------------------------------------------------------ //
+
+  internal func validateShape<Matrix:MatrixProtocol>(
+    forMatrix matrix: Matrix.Type,
+    columnCount: Int,
+    rowCount: Int) {
+
+    XCTAssertEqual(rowCount, matrix.rowCount)
+    XCTAssertEqual(columnCount, matrix.columnCount)
+    XCTAssertEqual(rowCount, matrix.columnLength)
+    XCTAssertEqual(columnCount, matrix.rowLength)
+    XCTAssertEqual(rowCount * columnCount, matrix.scalarCount)
+  }
+
+  func testHalfMatrix2x2Shape() {
+    self.validateShape(forMatrix: simd_half2x2.self, columnCount: 2, rowCount: 2)
+    self.validateShape(forMatrix: HalfMatrix2x2Storage.self, columnCount: 2, rowCount: 2)
+    self.validateShape(forMatrix: Matrix2x2<Float16>.self, columnCount: 2, rowCount: 2)
+  }
+
+  func testHalfMatrix2x3Shape() {
+    self.validateShape(forMatrix: simd_half2x3.self, columnCount: 2, rowCount: 3)
+    self.validateShape(forMatrix: HalfMatrix2x3Storage.self, columnCount: 2, rowCount: 3)
+    self.validateShape(forMatrix: Matrix2x3<Float16>.self, columnCount: 2, rowCount: 3)
+  }
+
+  func testHalfMatrix2x4Shape() {
+    self.validateShape(forMatrix: simd_half2x4.self, columnCount: 2, rowCount: 4)
+    self.validateShape(forMatrix: HalfMatrix2x4Storage.self, columnCount: 2, rowCount: 4)
+    self.validateShape(forMatrix: Matrix2x4<Float16>.self, columnCount: 2, rowCount: 4)
+  }
+
+  func testHalfMatrix3x2Shape() {
+    self.validateShape(forMatrix: simd_half3x2.self, columnCount: 3, rowCount: 2)
+    self.validateShape(forMatrix: HalfMatrix3x2Storage.self, columnCount: 3, rowCount: 2)
+    self.validateShape(forMatrix: Matrix3x2<Float16>.self, columnCount: 3, rowCount: 2)
+  }
+
+  func testHalfMatrix3x3Shape() {
+    self.validateShape(forMatrix: simd_half3x3.self, columnCount: 3, rowCount: 3)
+    self.validateShape(forMatrix: HalfMatrix3x3Storage.self, columnCount: 3, rowCount: 3)
+    self.validateShape(forMatrix: Matrix3x3<Float16>.self, columnCount: 3, rowCount: 3)
+  }
+
+  func testHalfMatrix3x4Shape() {
+    self.validateShape(forMatrix: simd_half3x4.self, columnCount: 3, rowCount: 4)
+    self.validateShape(forMatrix: HalfMatrix3x4Storage.self, columnCount: 3, rowCount: 4)
+    self.validateShape(forMatrix: Matrix3x4<Float16>.self, columnCount: 3, rowCount: 4)
+  }
+
+  func testHalfMatrix4x2Shape() {
+    self.validateShape(forMatrix: simd_half4x2.self, columnCount: 4, rowCount: 2)
+    self.validateShape(forMatrix: HalfMatrix4x2Storage.self, columnCount: 4, rowCount: 2)
+    self.validateShape(forMatrix: Matrix4x2<Float16>.self, columnCount: 4, rowCount: 2)
+  }
+
+  func testHalfMatrix4x3Shape() {
+    self.validateShape(forMatrix: simd_half4x3.self, columnCount: 4, rowCount: 3)
+    self.validateShape(forMatrix: HalfMatrix4x3Storage.self, columnCount: 4, rowCount: 3)
+    self.validateShape(forMatrix: Matrix4x3<Float16>.self, columnCount: 4, rowCount: 3)
+  }
+
+  func testHalfMatrix4x4Shape() {
+    self.validateShape(forMatrix: simd_half4x4.self, columnCount: 4, rowCount: 4)
+    self.validateShape(forMatrix: HalfMatrix4x4Storage.self, columnCount: 4, rowCount: 4)
+    self.validateShape(forMatrix: Matrix4x4<Float16>.self, columnCount: 4, rowCount: 4)
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/MatrixDistanceSanityTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/MatrixDistanceSanityTests.swift
@@ -1,0 +1,475 @@
+//
+//  MatrixDistanceSanityTests.swift
+//
+
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+class MatrixDistanceSanityTests: XCTestCase {
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Individual Validators
+  // ------------------------------------------------------------------------ //
+  //
+  // Each helper takes `l1` / `lInf` *closures* rather than calling the methods
+  // directly. The aggregate then runs every helper twice — once against the
+  // canonical `l1Distance` / `lInfinityDistance`, once against the generic
+  // reference `_l1Distance` / `_lInfinityDistance` — so the same battery of
+  // sanity checks verifies *both* code paths.
+
+  /// Sanity check: zero/self-distance is zero for any matrix.
+  internal func validateSelfDistanceIsZero<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    using label: String,
+    l1: (Matrix, Matrix) -> Matrix.Scalar,
+    lInf: (Matrix, Matrix) -> Matrix.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let zero = Matrix()
+    XCTAssertEqual(
+      l1(zero, zero),
+      0,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `l1(zero, zero) == 0`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(zero, zero),
+      0,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `lInf(zero, zero) == 0`.",
+      file: file,
+      line: line
+    )
+
+    var populated = Matrix()
+    var nextValue: Matrix.Scalar = 1
+    for position in Matrix.matrixPositions {
+      populated[position: position] = nextValue
+      nextValue += 1
+    }
+    XCTAssertEqual(
+      l1(populated, populated),
+      0,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `l1(populated, populated) == 0`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(populated, populated),
+      0,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `lInf(populated, populated) == 0`.",
+      file: file,
+      line: line
+    )
+  }
+
+  /// For every `(position, value)` pair, the matrix with `value` at `position` (and
+  /// zeros elsewhere) must be exactly `|value|` away from the zero matrix in both
+  /// L1 and L∞. If any slot is silently dropped this fails; if the helper indexes
+  /// a row that doesn't exist this traps.
+  internal func validateSingleEntryDistanceFromZero<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    using label: String,
+    l1: (Matrix, Matrix) -> Matrix.Scalar,
+    lInf: (Matrix, Matrix) -> Matrix.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let zero = Matrix()
+    let values: [Matrix.Scalar] = [1, -1, 2, -2]
+    for position in Matrix.matrixPositions {
+      for value in values {
+        var single = Matrix()
+        single[position: position] = value
+        let expected = abs(value)
+
+        XCTAssertEqual(
+          l1(single, zero),
+          expected,
+          "[\(label)] `\(String(reflecting: matrix))` at \(position) with value \(value): expected `l1(single, zero) == \(expected)`.",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          lInf(single, zero),
+          expected,
+          "[\(label)] `\(String(reflecting: matrix))` at \(position) with value \(value): expected `lInf(single, zero) == \(expected)`.",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          l1(zero, single),
+          expected,
+          "[\(label)] `\(String(reflecting: matrix))` at \(position) with value \(value): expected `l1(zero, single) == \(expected)` (symmetric).",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          lInf(zero, single),
+          expected,
+          "[\(label)] `\(String(reflecting: matrix))` at \(position) with value \(value): expected `lInf(zero, single) == \(expected)` (symmetric).",
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
+  /// Cartesian sweep of single-entry matrices against each other.
+  ///
+  /// - same position: L1 = L∞ = `|v₁ - v₂|`
+  /// - distinct positions: L1 = `|v₁| + |v₂|`, L∞ = `max(|v₁|, |v₂|)`
+  internal func validateSingleEntryPairDistances<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    using label: String,
+    l1: (Matrix, Matrix) -> Matrix.Scalar,
+    lInf: (Matrix, Matrix) -> Matrix.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let positions = Matrix.matrixPositions
+    let values: [Matrix.Scalar] = [1, -1]
+    for pos1 in positions {
+      for value1 in values {
+        var m1 = Matrix()
+        m1[position: pos1] = value1
+        for pos2 in positions {
+          for value2 in values {
+            var m2 = Matrix()
+            m2[position: pos2] = value2
+
+            let expectedL1: Matrix.Scalar
+            let expectedLInf: Matrix.Scalar
+            if pos1 == pos2 {
+              let diff = abs(value1 - value2)
+              expectedL1 = diff
+              expectedLInf = diff
+            } else {
+              let a1 = abs(value1)
+              let a2 = abs(value2)
+              expectedL1 = a1 + a2
+              expectedLInf = max(a1, a2)
+            }
+
+            XCTAssertEqual(
+              l1(m1, m2),
+              expectedL1,
+              "[\(label)] `\(String(reflecting: matrix))`: m1@\(pos1)=\(value1), m2@\(pos2)=\(value2): expected `l1 == \(expectedL1)`.",
+              file: file,
+              line: line
+            )
+            XCTAssertEqual(
+              lInf(m1, m2),
+              expectedLInf,
+              "[\(label)] `\(String(reflecting: matrix))`: m1@\(pos1)=\(value1), m2@\(pos2)=\(value2): expected `lInf == \(expectedLInf)`.",
+              file: file,
+              line: line
+            )
+          }
+        }
+      }
+    }
+  }
+
+  /// Populate every slot with `1` (via the position subscript — doesn't rely on
+  /// a possibly-buggy `init(repeating:)`). L1 distance to zero should equal the
+  /// scalar count; L∞ should equal 1.
+  internal func validateFullyPopulatedDistanceFromZero<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    using label: String,
+    l1: (Matrix, Matrix) -> Matrix.Scalar,
+    lInf: (Matrix, Matrix) -> Matrix.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let zero = Matrix()
+    var ones = Matrix()
+    for position in Matrix.matrixPositions {
+      ones[position: position] = 1
+    }
+
+    let expectedL1 = Matrix.Scalar(Matrix.scalarCount)
+    let expectedLInf: Matrix.Scalar = 1
+
+    XCTAssertEqual(
+      l1(ones, zero),
+      expectedL1,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `l1(ones, zero) == \(expectedL1)`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(ones, zero),
+      expectedLInf,
+      "[\(label)] `\(String(reflecting: matrix))`: expected `lInf(ones, zero) == \(expectedLInf)`.",
+      file: file,
+      line: line
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Cross-Check
+  // ------------------------------------------------------------------------ //
+
+  /// For each `(a, b)` in a deterministic sweep, assert that the canonical
+  /// `l1Distance` / `lInfinityDistance` agree with the generic reference
+  /// `_l1Distance` / `_lInfinityDistance` to within an epsilon. If a hand-
+  /// written per-shape implementation diverges from the spec for any input,
+  /// this surfaces it directly (regardless of whether the value happens to
+  /// match the analytic expectation in `validateSingleEntry*`).
+  internal func validateGenericMatchesCanonical<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let epsilon = Matrix.Scalar.validationTestTolerance
+
+    func compare(
+      _ a: Matrix,
+      _ b: Matrix,
+      scenario: @autoclosure () -> String
+    ) {
+      let canonicalL1 = a.l1Distance(to: b)
+      let genericL1 = a._l1Distance(to: b)
+      XCTAssertEqual(
+        canonicalL1,
+        genericL1,
+        accuracy: epsilon,
+        "`\(String(reflecting: matrix))` (l1 cross-check, \(scenario())): canonical \(canonicalL1) vs generic \(genericL1).",
+        file: file,
+        line: line
+      )
+
+      let canonicalLInf = a.lInfinityDistance(to: b)
+      let genericLInf = a._lInfinityDistance(to: b)
+      XCTAssertEqual(
+        canonicalLInf,
+        genericLInf,
+        accuracy: epsilon,
+        "`\(String(reflecting: matrix))` (lInf cross-check, \(scenario())): canonical \(canonicalLInf) vs generic \(genericLInf).",
+        file: file,
+        line: line
+      )
+    }
+
+    let zero = Matrix()
+    compare(zero, zero, scenario: "zero-zero")
+
+    let values: [Matrix.Scalar] = [1, -1, 2, -2]
+    for position in Matrix.matrixPositions {
+      for value in values {
+        var single = Matrix()
+        single[position: position] = value
+        compare(single, zero, scenario: "single@\(position)=\(value), zero")
+        compare(zero, single, scenario: "zero, single@\(position)=\(value)")
+      }
+    }
+
+    var ones = Matrix()
+    for position in Matrix.matrixPositions {
+      ones[position: position] = 1
+    }
+    compare(ones, zero, scenario: "ones, zero")
+    compare(zero, ones, scenario: "zero, ones")
+
+    var ramped = Matrix()
+    var step: Matrix.Scalar = 1
+    for position in Matrix.matrixPositions {
+      ramped[position: position] = step
+      step += 1
+    }
+    compare(ramped, zero, scenario: "ramped, zero")
+    compare(ramped, ones, scenario: "ramped, ones")
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Aggregate Validator
+  // ------------------------------------------------------------------------ //
+
+  internal func validateMatrixDistanceFunctions<Matrix>(
+    forMatrix matrix: Matrix.Type,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Matrix: MatrixProtocol,
+    Matrix: L1DistanceMeasureable,
+    Matrix: LInfinityDistanceMeasureable,
+    Matrix.L1Distance == Matrix.Scalar,
+    Matrix.LInfinityDistance == Matrix.Scalar
+  {
+    let canonicalL1: (Matrix, Matrix) -> Matrix.Scalar = { $0.l1Distance(to: $1) }
+    let canonicalLInf: (Matrix, Matrix) -> Matrix.Scalar = { $0.lInfinityDistance(to: $1) }
+    let genericL1: (Matrix, Matrix) -> Matrix.Scalar = { $0._l1Distance(to: $1) }
+    let genericLInf: (Matrix, Matrix) -> Matrix.Scalar = { $0._lInfinityDistance(to: $1) }
+
+    for (label, l1, lInf) in [
+      ("canonical", canonicalL1, canonicalLInf),
+      ("generic", genericL1, genericLInf)
+    ] {
+      self.validateSelfDistanceIsZero(
+        forMatrix: matrix,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateFullyPopulatedDistanceFromZero(
+        forMatrix: matrix,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateSingleEntryDistanceFromZero(
+        forMatrix: matrix,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateSingleEntryPairDistances(
+        forMatrix: matrix,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+    }
+
+    self.validateGenericMatchesCanonical(
+      forMatrix: matrix,
+      file: file,
+      line: line
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: (2, _) Shapes
+  // ------------------------------------------------------------------------ //
+
+  func testMatrix2x2() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double2x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float2x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half2x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x2<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x2<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x2<Float16>.self)
+  }
+
+  func testMatrix2x3() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double2x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float2x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half2x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x3<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x3<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x3<Float16>.self)
+  }
+
+  func testMatrix2x4() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double2x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float2x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half2x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x4<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x4<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix2x4<Float16>.self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: (3, _) Shapes
+  // ------------------------------------------------------------------------ //
+
+  func testMatrix3x2() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double3x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float3x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half3x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x2<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x2<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x2<Float16>.self)
+  }
+
+  func testMatrix3x3() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double3x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float3x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half3x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x3<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x3<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x3<Float16>.self)
+  }
+
+  func testMatrix3x4() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double3x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float3x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half3x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x4<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x4<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix3x4<Float16>.self)
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: (4, _) Shapes
+  // ------------------------------------------------------------------------ //
+
+  func testMatrix4x2() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double4x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float4x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half4x2.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x2<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x2<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x2<Float16>.self)
+  }
+
+  func testMatrix4x3() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double4x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float4x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half4x3.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x3<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x3<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x3<Float16>.self)
+  }
+
+  func testMatrix4x4() {
+    self.validateMatrixDistanceFunctions(forMatrix: simd_double4x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_float4x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: simd_half4x4.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x4<Double>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x4<Float>.self)
+    self.validateMatrixDistanceFunctions(forMatrix: Matrix4x4<Float16>.self)
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/MatrixInitRepeatingTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Matrices/Matrices/MatrixInitRepeatingTests.swift
@@ -1,0 +1,243 @@
+//
+//  MatrixInitRepeatingTests.swift
+//
+
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+/// Exercises `MatrixProtocol.init(repeating:)` across the native, storage, and
+/// wrapper layers for `Float16`, `Float`, and `Double`.
+///
+/// The protocol contract says `init(repeating: s)` "constructs a matrix with
+/// `scalar` inserted into *all entries*" — not just the diagonal. The
+/// half-precision conformances originally delegated to `init(diagonal:)`, which
+/// silently produced a diagonal-only matrix with zeros off-diagonal; these
+/// tests would fail under that implementation.
+class MatrixInitRepeatingTests: XCTestCase {
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Helper
+  // ------------------------------------------------------------------------ //
+
+  /// Builds `Matrix(repeating: scalar)` and asserts every linearized scalar
+  /// equals `scalar`. A diagonal-only result fails on every off-diagonal slot.
+  internal func validateInitRepeating<Matrix:MatrixProtocol>(
+    forMatrix matrix: Matrix.Type,
+    scalar: Matrix.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let populated = Matrix(repeating: scalar)
+    let scalars = populated.linearizedScalars
+    XCTAssertEqual(
+      scalars.count,
+      Matrix.scalarCount,
+      "`\(String(reflecting: matrix))`: linearizedScalars length should match scalarCount.",
+      file: file,
+      line: line
+    )
+    for (index, value) in scalars.enumerated() {
+      XCTAssertEqual(
+        value,
+        scalar,
+        "`\(String(reflecting: matrix))`: entry \(index) was \(value), expected \(scalar) (init(repeating:) must fill every entry).",
+        file: file,
+        line: line
+      )
+    }
+  }
+
+  /// Runs `validateInitRepeating` against three representative scalar values
+  /// (including a negative and zero) for every layer of a given shape.
+  internal func validateInitRepeatingAcrossLayers<
+    Native:MatrixProtocol,
+    Storage:MatrixProtocol,
+    Wrapper:MatrixProtocol
+  >(
+    native: Native.Type,
+    storage: Storage.Type,
+    wrapper: Wrapper.Type,
+    scalars: [Native.Scalar],
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Native.Scalar == Storage.Scalar,
+    Storage.Scalar == Wrapper.Scalar
+  {
+    for scalar in scalars {
+      validateInitRepeating(
+        forMatrix: native,
+        scalar: scalar,
+        file: file,
+        line: line
+      )
+      validateInitRepeating(
+        forMatrix: storage,
+        scalar: scalar as Storage.Scalar,
+        file: file,
+        line: line
+      )
+      validateInitRepeating(
+        forMatrix: wrapper,
+        scalar: scalar as Wrapper.Scalar,
+        file: file,
+        line: line
+      )
+    }
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Float16
+  // ------------------------------------------------------------------------ //
+
+  private let halfScalars: [Float16] = [-1.5, 0, 2.25]
+
+  func testHalfMatrix2x2InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half2x2.self,
+      storage: HalfMatrix2x2Storage.self,
+      wrapper: Matrix2x2<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix2x3InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half2x3.self,
+      storage: HalfMatrix2x3Storage.self,
+      wrapper: Matrix2x3<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix2x4InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half2x4.self,
+      storage: HalfMatrix2x4Storage.self,
+      wrapper: Matrix2x4<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix3x2InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half3x2.self,
+      storage: HalfMatrix3x2Storage.self,
+      wrapper: Matrix3x2<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix3x3InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half3x3.self,
+      storage: HalfMatrix3x3Storage.self,
+      wrapper: Matrix3x3<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix3x4InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half3x4.self,
+      storage: HalfMatrix3x4Storage.self,
+      wrapper: Matrix3x4<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix4x2InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half4x2.self,
+      storage: HalfMatrix4x2Storage.self,
+      wrapper: Matrix4x2<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix4x3InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half4x3.self,
+      storage: HalfMatrix4x3Storage.self,
+      wrapper: Matrix4x3<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  func testHalfMatrix4x4InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_half4x4.self,
+      storage: HalfMatrix4x4Storage.self,
+      wrapper: Matrix4x4<Float16>.self,
+      scalars: halfScalars
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Float (baseline — confirms the contract is encoded the same way)
+  // ------------------------------------------------------------------------ //
+
+  private let floatScalars: [Float] = [-1.5, 0, 2.25]
+
+  func testFloatMatrix2x2InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_float2x2.self,
+      storage: FloatMatrix2x2Storage.self,
+      wrapper: Matrix2x2<Float>.self,
+      scalars: floatScalars
+    )
+  }
+
+  func testFloatMatrix3x3InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_float3x3.self,
+      storage: FloatMatrix3x3Storage.self,
+      wrapper: Matrix3x3<Float>.self,
+      scalars: floatScalars
+    )
+  }
+
+  func testFloatMatrix4x4InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_float4x4.self,
+      storage: FloatMatrix4x4Storage.self,
+      wrapper: Matrix4x4<Float>.self,
+      scalars: floatScalars
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Double (baseline)
+  // ------------------------------------------------------------------------ //
+
+  private let doubleScalars: [Double] = [-1.5, 0, 2.25]
+
+  func testDoubleMatrix2x2InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_double2x2.self,
+      storage: DoubleMatrix2x2Storage.self,
+      wrapper: Matrix2x2<Double>.self,
+      scalars: doubleScalars
+    )
+  }
+
+  func testDoubleMatrix3x3InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_double3x3.self,
+      storage: DoubleMatrix3x3Storage.self,
+      wrapper: Matrix3x3<Double>.self,
+      scalars: doubleScalars
+    )
+  }
+
+  func testDoubleMatrix4x4InitRepeating() {
+    validateInitRepeatingAcrossLayers(
+      native: simd_double4x4.self,
+      storage: DoubleMatrix4x4Storage.self,
+      wrapper: Matrix4x4<Double>.self,
+      scalars: doubleScalars
+    )
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Matrices/Storages/Half/HalfMatrixMemoryLayoutTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Matrices/Storages/Half/HalfMatrixMemoryLayoutTests.swift
@@ -1,0 +1,83 @@
+//
+//  HalfMatrixMemoryLayoutTests.swift
+//
+
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+class HalfMatrixMemoryLayoutTests: XCTestCase {
+
+  func testHalfMatrix2x2NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half2x2.self,
+      Float16.Matrix2x2Storage.self,
+      Matrix2x2<Float16>.self
+    )
+  }
+
+  func testHalfMatrix2x3NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half2x3.self,
+      Float16.Matrix2x3Storage.self,
+      Matrix2x3<Float16>.self
+    )
+  }
+
+  func testHalfMatrix2x4NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half2x4.self,
+      Float16.Matrix2x4Storage.self,
+      Matrix2x4<Float16>.self
+    )
+  }
+
+  func testHalfMatrix3x2NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half3x2.self,
+      Float16.Matrix3x2Storage.self,
+      Matrix3x2<Float16>.self
+    )
+  }
+
+  func testHalfMatrix3x3NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half3x3.self,
+      Float16.Matrix3x3Storage.self,
+      Matrix3x3<Float16>.self
+    )
+  }
+
+  func testHalfMatrix3x4NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half3x4.self,
+      Float16.Matrix3x4Storage.self,
+      Matrix3x4<Float16>.self
+    )
+  }
+
+  func testHalfMatrix4x2NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half4x2.self,
+      Float16.Matrix4x2Storage.self,
+      Matrix4x2<Float16>.self
+    )
+  }
+
+  func testHalfMatrix4x3NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half4x3.self,
+      Float16.Matrix4x3Storage.self,
+      Matrix4x3<Float16>.self
+    )
+  }
+
+  func testHalfMatrix4x4NoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_half4x4.self,
+      Float16.Matrix4x4Storage.self,
+      Matrix4x4<Float16>.self
+    )
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Quaternions/HalfQuaternionValidationTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Quaternions/HalfQuaternionValidationTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+// `simd_quath` lacks the Swift overlay's bridged operators and `.real` /
+// `.imag` / `.conjugate` / `.inverse` accessors that `simd_quatf` and
+// `simd_quatd` ship with; we route the "native" side of each comparison
+// through the free C functions instead. We also pick a more lenient
+// tolerance than the default — `Float16` only has ~3 decimal digits of
+// precision and the default `.validationTestTolerance` of `1e-6` rounds to
+// subnormal when stored in `Float16`.
+
+extension Float16 {
+  /// Override of `BinaryFloatingPoint.validationTestTolerance` suited to
+  /// `Float16`'s ~3-decimal-digit precision.
+  static var validationTestTolerance: Float16 { 0.05 }
+}
+
+class HalfQuaternionValidationTests: QuaternionValidationTestCase {
+
+  lazy var probeScalars: some Collection<Float16> = [
+    Float16(-5.0), Float16(-4.5), Float16(-4.0), Float16(-3.5),
+    Float16(-3.0), Float16(-2.5), Float16(-2.0), Float16(-1.5),
+    Float16(-1.0), Float16(-0.5), Float16(0.0),
+    Float16(0.5), Float16(1.0), Float16(1.5), Float16(2.0),
+    Float16(2.5), Float16(3.0), Float16(3.5), Float16(4.0),
+    Float16(4.5), Float16(5.0)
+  ]
+
+  lazy var nonZeroProbeScalars: some Collection<Float16> =
+    probeScalars.filter(\.isNonZero)
+
+  let scalar: Float16.Type = Float16.self
+  let aggregate: Quaternion<Float16>.Type = Quaternion<Float16>.self
+
+  func testProbeScalarSanity() {
+    XCTAssertFalse(probeScalars.isEmpty)
+    XCTAssertTrue(probeScalars.allSatisfy(\.isFinite))
+    XCTAssertTrue(probeScalars.contains(where: { $0.isStrictlyPositive }))
+    XCTAssertTrue(probeScalars.contains(where: { $0.isStrictlyNegative }))
+    XCTAssertTrue(probeScalars.contains(where: { $0.isZero }))
+  }
+
+  func testNonZeroProbeScalarSanity() {
+    XCTAssertFalse(nonZeroProbeScalars.isEmpty)
+    XCTAssertTrue(nonZeroProbeScalars.allSatisfy(\.isFiniteNonZero))
+    XCTAssertTrue(nonZeroProbeScalars.contains(where: { $0.isStrictlyPositive }))
+    XCTAssertTrue(nonZeroProbeScalars.contains(where: { $0.isStrictlyNegative }))
+    XCTAssertFalse(nonZeroProbeScalars.contains(where: { $0.isZero }))
+  }
+
+  func testOutOfPlaceScalarLHSMultiplication() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceScalarAggregateToAggregateOperation(
+        "*",
+        on: (scalar, aggregate),
+        lhses: probeScalars,
+        rhses: probeTuples,
+        operations: { $0 * $1 }, { simd_mul($0, $1) }
+      )
+    }
+  }
+
+  func testOutOfPlaceScalarRHSMultiplication() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateScalarToAggregateOperation(
+        "*",
+        on: (aggregate, scalar),
+        lhses: probeTuples,
+        rhses: probeScalars,
+        operations: { $0 * $1 }, { simd_mul($1, $0) }
+      )
+    }
+  }
+
+  func testOutOfPlaceScalarRHSDivision() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateScalarToAggregateOperation(
+        "/",
+        on: (aggregate, scalar),
+        lhses: probeTuples,
+        rhses: nonZeroProbeScalars,
+        operations: { $0 / $1 }, { simd_quath(vector: $0.vector / $1) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionAddition() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateAggregateToAggregateOperation(
+        "+",
+        on: (aggregate, aggregate),
+        lhses: probeTuples,
+        rhses: probeTuples,
+        operations: { $0 + $1 },
+        { simd_quath(vector: $0.vector + $1.vector) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionSubtraction() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateAggregateToAggregateOperation(
+        "-",
+        on: (aggregate, aggregate),
+        lhses: probeTuples,
+        rhses: probeTuples,
+        operations: { $0 - $1 },
+        { simd_quath(vector: $0.vector - $1.vector) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionMultiplication() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateAggregateToAggregateOperation(
+        "*",
+        on: (aggregate, aggregate),
+        lhses: probeTuples,
+        rhses: probeTuples,
+        operations: { $0 * $1 }, { simd_mul($0, $1) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionDivision() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateAggregateToAggregateOperation(
+        "/",
+        on: (aggregate, aggregate),
+        lhses: probeTuples,
+        rhses: nonZeroProbeTuples,
+        operations: { $0 / $1 }, { simd_mul($0, simd_inverse($1)) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionConjugation() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateToAggregateOperation(
+        "conjugate",
+        on: (aggregate),
+        probes: probeTuples,
+        operations: { $0.conjugated() }, { simd_conjugate($0) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionNegation() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateToAggregateOperation(
+        ".negated()",
+        on: (aggregate),
+        probes: probeTuples,
+        operations: { $0.negated() }, { simd_quath(vector: -$0.vector) }
+      )
+    }
+  }
+
+  func testOutOfPlaceQuaternionInversion() async throws {
+    try await withFailureReaction(.haltImmediately) {
+      try await HDXLValidateOutOfPlaceAggregateToAggregateOperation(
+        ".inverted()",
+        on: (aggregate),
+        probes: nonZeroProbeTuples,
+        operations: { $0.inverted() }, { simd_inverse($0) }
+      )
+    }
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Quaternions/QuaternionDistanceSanityTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Quaternions/QuaternionDistanceSanityTests.swift
@@ -1,0 +1,390 @@
+//
+//  QuaternionDistanceSanityTests.swift
+//
+
+import XCTest
+import simd
+@testable import HDXLSIMDSupport
+
+class QuaternionDistanceSanityTests: XCTestCase {
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Component Construction Helper
+  // ------------------------------------------------------------------------ //
+
+  /// Construct a quaternion whose only nonzero component is at `componentIndex`,
+  /// where 0=real, 1=i, 2=j, 3=k.
+  private func singleComponentQuaternion<Q>(
+    _ quaternionType: Q.Type,
+    at componentIndex: Int,
+    value: Q.Scalar
+  ) -> Q where Q: QuaternionProtocol {
+    precondition((0...3).contains(componentIndex))
+    return Q(
+      i: componentIndex == 1 ? value : 0,
+      j: componentIndex == 2 ? value : 0,
+      k: componentIndex == 3 ? value : 0,
+      real: componentIndex == 0 ? value : 0
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Individual Validators
+  // ------------------------------------------------------------------------ //
+  //
+  // Each helper takes `l1` / `lInf` closures so the aggregate can exercise the
+  // same sanity battery against both the canonical methods and the generic
+  // reference (`_l1Distance` / `_lInfinityDistance`).
+
+  /// Sanity check: zero/self-distance is zero.
+  internal func validateSelfDistanceIsZero<Q>(
+    forQuaternion quaternion: Q.Type,
+    using label: String,
+    l1: (Q, Q) -> Q.Scalar,
+    lInf: (Q, Q) -> Q.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let zero = Q()
+    XCTAssertEqual(
+      l1(zero, zero),
+      0,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `l1(zero, zero) == 0`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(zero, zero),
+      0,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `lInf(zero, zero) == 0`.",
+      file: file,
+      line: line
+    )
+
+    let populated = Q(i: 1, j: 2, k: 3, real: 4)
+    XCTAssertEqual(
+      l1(populated, populated),
+      0,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `l1(populated, populated) == 0`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(populated, populated),
+      0,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `lInf(populated, populated) == 0`.",
+      file: file,
+      line: line
+    )
+  }
+
+  /// For each `(componentIndex, value)`, the quaternion with that single nonzero
+  /// component must be exactly `|value|` away from the zero quaternion in L1
+  /// and L∞.
+  internal func validateSingleComponentDistanceFromZero<Q>(
+    forQuaternion quaternion: Q.Type,
+    using label: String,
+    l1: (Q, Q) -> Q.Scalar,
+    lInf: (Q, Q) -> Q.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let zero = Q()
+    let values: [Q.Scalar] = [1, -1, 2, -2]
+    for componentIndex in 0...3 {
+      for value in values {
+        let single = self.singleComponentQuaternion(
+          quaternion,
+          at: componentIndex,
+          value: value
+        )
+        let expected = abs(value)
+
+        XCTAssertEqual(
+          l1(single, zero),
+          expected,
+          "[\(label)] `\(String(reflecting: quaternion))` component \(componentIndex) value \(value): expected `l1(single, zero) == \(expected)`.",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          lInf(single, zero),
+          expected,
+          "[\(label)] `\(String(reflecting: quaternion))` component \(componentIndex) value \(value): expected `lInf(single, zero) == \(expected)`.",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          l1(zero, single),
+          expected,
+          "[\(label)] `\(String(reflecting: quaternion))` component \(componentIndex) value \(value): expected `l1(zero, single) == \(expected)` (symmetric).",
+          file: file,
+          line: line
+        )
+        XCTAssertEqual(
+          lInf(zero, single),
+          expected,
+          "[\(label)] `\(String(reflecting: quaternion))` component \(componentIndex) value \(value): expected `lInf(zero, single) == \(expected)` (symmetric).",
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
+  /// Cartesian sweep of single-component quaternions against each other.
+  ///
+  /// - same component: L1 = L∞ = `|v₁ - v₂|`
+  /// - distinct components: L1 = `|v₁| + |v₂|`, L∞ = `max(|v₁|, |v₂|)`
+  internal func validateSingleComponentPairDistances<Q>(
+    forQuaternion quaternion: Q.Type,
+    using label: String,
+    l1: (Q, Q) -> Q.Scalar,
+    lInf: (Q, Q) -> Q.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let values: [Q.Scalar] = [1, -1]
+    for c1 in 0...3 {
+      for value1 in values {
+        let q1 = self.singleComponentQuaternion(quaternion, at: c1, value: value1)
+        for c2 in 0...3 {
+          for value2 in values {
+            let q2 = self.singleComponentQuaternion(quaternion, at: c2, value: value2)
+
+            let expectedL1: Q.Scalar
+            let expectedLInf: Q.Scalar
+            if c1 == c2 {
+              let diff = abs(value1 - value2)
+              expectedL1 = diff
+              expectedLInf = diff
+            } else {
+              let a1 = abs(value1)
+              let a2 = abs(value2)
+              expectedL1 = a1 + a2
+              expectedLInf = max(a1, a2)
+            }
+
+            XCTAssertEqual(
+              l1(q1, q2),
+              expectedL1,
+              "[\(label)] `\(String(reflecting: quaternion))`: q1@\(c1)=\(value1), q2@\(c2)=\(value2): expected `l1 == \(expectedL1)`.",
+              file: file,
+              line: line
+            )
+            XCTAssertEqual(
+              lInf(q1, q2),
+              expectedLInf,
+              "[\(label)] `\(String(reflecting: quaternion))`: q1@\(c1)=\(value1), q2@\(c2)=\(value2): expected `lInf == \(expectedLInf)`.",
+              file: file,
+              line: line
+            )
+          }
+        }
+      }
+    }
+  }
+
+  /// All four components = 1: L1 distance to zero should be 4; L∞ should be 1.
+  internal func validateFullyPopulatedDistanceFromZero<Q>(
+    forQuaternion quaternion: Q.Type,
+    using label: String,
+    l1: (Q, Q) -> Q.Scalar,
+    lInf: (Q, Q) -> Q.Scalar,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let zero = Q()
+    let ones = Q(i: 1, j: 1, k: 1, real: 1)
+
+    XCTAssertEqual(
+      l1(ones, zero),
+      4,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `l1(ones, zero) == 4`.",
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      lInf(ones, zero),
+      1,
+      "[\(label)] `\(String(reflecting: quaternion))`: expected `lInf(ones, zero) == 1`.",
+      file: file,
+      line: line
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Cross-Check
+  // ------------------------------------------------------------------------ //
+
+  /// For each `(a, b)` in a deterministic sweep, assert that the canonical
+  /// methods and the generic reference agree within epsilon.
+  internal func validateGenericMatchesCanonical<Q>(
+    forQuaternion quaternion: Q.Type,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let epsilon = Q.Scalar.validationTestTolerance
+
+    func compare(
+      _ a: Q,
+      _ b: Q,
+      scenario: @autoclosure () -> String
+    ) {
+      let canonicalL1 = a.l1Distance(to: b)
+      let genericL1 = a._l1Distance(to: b)
+      XCTAssertEqual(
+        canonicalL1,
+        genericL1,
+        accuracy: epsilon,
+        "`\(String(reflecting: quaternion))` (l1 cross-check, \(scenario())): canonical \(canonicalL1) vs generic \(genericL1).",
+        file: file,
+        line: line
+      )
+
+      let canonicalLInf = a.lInfinityDistance(to: b)
+      let genericLInf = a._lInfinityDistance(to: b)
+      XCTAssertEqual(
+        canonicalLInf,
+        genericLInf,
+        accuracy: epsilon,
+        "`\(String(reflecting: quaternion))` (lInf cross-check, \(scenario())): canonical \(canonicalLInf) vs generic \(genericLInf).",
+        file: file,
+        line: line
+      )
+    }
+
+    let zero = Q()
+    compare(zero, zero, scenario: "zero-zero")
+
+    let values: [Q.Scalar] = [1, -1, 2, -2]
+    for componentIndex in 0...3 {
+      for value in values {
+        let single = self.singleComponentQuaternion(
+          quaternion,
+          at: componentIndex,
+          value: value
+        )
+        compare(single, zero, scenario: "single@\(componentIndex)=\(value), zero")
+        compare(zero, single, scenario: "zero, single@\(componentIndex)=\(value)")
+      }
+    }
+
+    let ones = Q(i: 1, j: 1, k: 1, real: 1)
+    compare(ones, zero, scenario: "ones, zero")
+    compare(zero, ones, scenario: "zero, ones")
+
+    let ramped = Q(i: 1, j: 2, k: 3, real: 4)
+    compare(ramped, zero, scenario: "ramped, zero")
+    compare(ramped, ones, scenario: "ramped, ones")
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Aggregate Validator
+  // ------------------------------------------------------------------------ //
+
+  internal func validateQuaternionDistanceFunctions<Q>(
+    forQuaternion quaternion: Q.Type,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) where
+    Q: QuaternionProtocol,
+    Q: L1DistanceMeasureable,
+    Q: LInfinityDistanceMeasureable,
+    Q.L1Distance == Q.Scalar,
+    Q.LInfinityDistance == Q.Scalar
+  {
+    let canonicalL1: (Q, Q) -> Q.Scalar = { $0.l1Distance(to: $1) }
+    let canonicalLInf: (Q, Q) -> Q.Scalar = { $0.lInfinityDistance(to: $1) }
+    let genericL1: (Q, Q) -> Q.Scalar = { $0._l1Distance(to: $1) }
+    let genericLInf: (Q, Q) -> Q.Scalar = { $0._lInfinityDistance(to: $1) }
+
+    for (label, l1, lInf) in [
+      ("canonical", canonicalL1, canonicalLInf),
+      ("generic", genericL1, genericLInf)
+    ] {
+      self.validateSelfDistanceIsZero(
+        forQuaternion: quaternion,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateFullyPopulatedDistanceFromZero(
+        forQuaternion: quaternion,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateSingleComponentDistanceFromZero(
+        forQuaternion: quaternion,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+      self.validateSingleComponentPairDistances(
+        forQuaternion: quaternion,
+        using: label,
+        l1: l1,
+        lInf: lInf,
+        file: file,
+        line: line
+      )
+    }
+
+    self.validateGenericMatchesCanonical(
+      forQuaternion: quaternion,
+      file: file,
+      line: line
+    )
+  }
+
+  // ------------------------------------------------------------------------ //
+  // MARK: Test Method
+  // ------------------------------------------------------------------------ //
+
+  func testQuaternion() {
+    self.validateQuaternionDistanceFunctions(forQuaternion: simd_quatd.self)
+    self.validateQuaternionDistanceFunctions(forQuaternion: simd_quatf.self)
+    self.validateQuaternionDistanceFunctions(forQuaternion: simd_quath.self)
+    self.validateQuaternionDistanceFunctions(forQuaternion: Quaternion<Double>.self)
+    self.validateQuaternionDistanceFunctions(forQuaternion: Quaternion<Float>.self)
+    self.validateQuaternionDistanceFunctions(forQuaternion: Quaternion<Float16>.self)
+  }
+
+}

--- a/Tests/HDXLSIMDSupportTests/Tests/Quaternions/QuaternionMemoryLayoutTests.swift
+++ b/Tests/HDXLSIMDSupportTests/Tests/Quaternions/QuaternionMemoryLayoutTests.swift
@@ -22,4 +22,11 @@ class QuaternionMemoryLayoutTests: XCTestCase {
     )
   }
 
+  func testHalfQuaternionNoPaddingAdded() {
+    AssertMemoryEquivalentMemoryLayouts(
+      simd_quath.self,
+      HalfQuaternionStorage.self
+    )
+  }
+
 }


### PR DESCRIPTION
## Summary

- Adds `Float16: ExtendedSIMDScalar` so `Quaternion<Float16>` and `Matrix{N}x{M}<Float16>` work generically alongside `Float`/`Double`, mirroring the existing storage/native-conformance pattern.
- Chose **option 2** (wrap the native types) over a protocol split: `simd_quath` and `simd_half{N}x{M}` already exist with all the C-level operations; what's missing is just the Swift-overlay convenience layer (`.real`/`.imag`/operators/`init(diagonal:)`/etc.), which this fills in.
- Works around a macOS 26 Swift-overlay bug where `simd_*` functions returning a `simd_halfNx3` (any half-precision shape with `SIMD3<Float16>` columns) miscompute their result by value: the half-3-row conformances implement their matrix-returning operations in pure Swift, and `HalfMatrix3x3Storage.init(quaternion:)` extracts the 3×3 from `simd_matrix4x4(quath)` rather than calling the broken `simd_matrix3x3(quath)`. Each workaround is commented at its site.
- **`init(repeating:)` fix** (in its own commit, surfaced while writing follow-up tests): the `MatrixProtocol` contract says `init(repeating: s)` fills *every entry*, but every native conformance built only a diagonal. `simd_half*` was the originally-flagged case (it routed through `init(diagonal:)`); writing the test across scalars revealed `simd_float*` and `simd_double*` had the same bug — they delegated to the bridged `init(_ scalar:)` constructor, which in the Swift simd overlay is itself a *diagonal* initializer (`simd_double2x2(2.5) == [[2.5, 0], [0, 2.5]]`, not a uniform fill). The fix builds an all-`scalar` `ColumnVector` and replicates it across every column on each native shape; the new `MatrixInitRepeatingTests` covers native, storage, and wrapper layers for `Float16`/`Float`/`Double`.

## Test plan

- [x] `swift build` — clean.
- [x] `swift test` — 133/133 passing, including new `HalfMatrixMemoryLayoutTests`, `HalfMatrixShapeSanityTests`, `HalfQuaternionValidationTests`, `MatrixInitRepeatingTests`, and a `simd_quath` case added to `QuaternionMemoryLayoutTests`.